### PR TITLE
Averaging Down feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,5 @@
 # v1.0.0-beta (DEPRECATED)
 
 * Integration with Trading View notifications and Binance to buy or sell coins.
-* A moving stop-loss limit, which goes up together with the price.
+* A moving stop-limit, which goes up together with the price.
 * A simple UI to display currently tracked assets and the total profit counter.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The project to help you with crypto trading, written for Google Apps Script.
 The current features are:
 * Integration with Binance: buy and sell coins on the spot.
 * Set up your profit and loss limits to automatically sell coins when you reach them.
-* A moving stop-loss limit, which goes up together with the price.
+* A moving stop-limit, which goes up together with the price.
 * Swing trading: automatically sell and buy coins when the price goes up or down.
 * Your statistics: see how much you have made and how much you have lost on a daily basis.
 

--- a/apps-script/Binance.ts
+++ b/apps-script/Binance.ts
@@ -84,7 +84,7 @@ export class Binance implements IExchange {
     if (moneyAvailable < cost) {
       return new TradeResult(symbol, `Not enough money to buy: ${symbol.priceAsset}=${moneyAvailable}`)
     }
-    Log.alert(`Buying ${symbol}`);
+    Log.alert(`Buying ${symbol} for ${cost} ${symbol.priceAsset}`)
     const query = `symbol=${symbol}&type=MARKET&side=BUY&quoteOrderQty=${cost}`;
     const tradeResult = this.marketTrade(symbol, query);
     tradeResult.symbol = symbol

--- a/apps-script/Common.ts
+++ b/apps-script/Common.ts
@@ -23,7 +23,7 @@ function execute({context, runnable, interval = 500, attempts = 5}: ExecParams) 
     }
   } while (--attempts > 0);
 
-  Log.error(new Error(`All attempts failed. Context: ${JSON.stringify(context)}. Message: ${err.message}. Stacktrace: ${err.stack}`));
+  Log.error(new Error(`All attempts failed. Context: ${JSON.stringify(context)}. Message: ${err.message}`));
   throw err;
 }
 

--- a/apps-script/Common.ts
+++ b/apps-script/Common.ts
@@ -23,7 +23,7 @@ function execute({context, runnable, interval = 500, attempts = 5}: ExecParams) 
     }
   } while (--attempts > 0);
 
-  Log.error(new Error(`All attempts failed. Context: ${JSON.stringify(context)}. Error message: ${err.message}`));
+  Log.error(new Error(`All attempts failed. Context: ${JSON.stringify(context)}. Message: ${err.message}. Stacktrace: ${err.stack}`));
   throw err;
 }
 
@@ -51,7 +51,7 @@ class Log {
 
   static print(): string {
     return `${this.alerts.length > 0 ? `${this.alerts.join('\n')}\n\n` : ''}
-${this.errLog.length > 0 ? `Errors:\n${this.errLog.join('\n')}` : ''}
+${this.errLog.length > 0 ? `Errors:\n${this.errLog.map(e => `Message: ${e.message}\nStacktrace: ${e.stack}`).join('\n')}` : ''}
 ${this.infoLog.length > 0 ? `Info:\n${this.infoLog.join('\n')}` : ''}
 ${this.debugLog.length > 0 ? `Debug:\n${this.debugLog.map(v => JSON.stringify(v)).join('\n\n')}` : ''}
 `

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -58,7 +58,7 @@ export class FirebaseStore implements IStore {
 
   getConfig(): Config {
     const configCacheJson = CacheProxy.get("Config");
-    let configCache = configCacheJson ? JSON.parse(configCacheJson) : null;
+    let configCache: Config = configCacheJson ? JSON.parse(configCacheJson) : null;
     if (!configCache) {
       const defaultConfig: Config = {
         KEY: '',
@@ -74,8 +74,25 @@ export class FirebaseStore implements IStore {
         AveragingDown: false,
       }
       configCache = this.getOrSet("Config", defaultConfig)
-      CacheProxy.put("Config", JSON.stringify(configCache))
     }
+
+    if (configCache.TakeProfit) {
+      configCache.ProfitLimit = configCache.TakeProfit
+      delete configCache.TakeProfit
+    }
+
+    if (configCache.SellAtTakeProfit) {
+      configCache.SellAtProfitLimit = configCache.SellAtTakeProfit
+      delete configCache.SellAtTakeProfit
+    }
+
+    if (configCache.LossLimit) {
+      configCache.StopLimit = configCache.LossLimit
+      delete configCache.LossLimit
+    }
+
+    CacheProxy.put("Config", JSON.stringify(configCache))
+
     return configCache;
   }
 
@@ -177,6 +194,19 @@ export type Config = {
    * the tool will gradually sell all assets without loss.
    */
   AveragingDown: boolean
+
+  /**
+   * @deprecated
+   */
+  TakeProfit?: number
+  /**
+   * @deprecated
+   */
+  LossLimit?: number
+  /**
+   * @deprecated
+   */
+  SellAtTakeProfit?: boolean
 }
 
 // @ts-ignore

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -61,14 +61,14 @@ export class FirebaseStore implements IStore {
     let configCache = configCacheJson ? JSON.parse(configCacheJson) : null;
     if (!configCache) {
       const defaultConfig: Config = {
-        TakeProfit: 0.1,
-        SellAtTakeProfit: true,
-        BuyQuantity: 10,
-        LossLimit: 0.05,
-        SECRET: '',
         KEY: '',
+        SECRET: '',
+        BuyQuantity: 10,
         PriceAsset: StableCoin.USDT,
+        StopLimit: 0.05,
+        ProfitLimit: 0.1,
         SellAtStopLimit: false,
+        SellAtProfitLimit: true,
         SwingTradeEnabled: false,
         PriceProvider: PriceProvider.Binance,
         AveragingDown: false,
@@ -157,20 +157,20 @@ export class FirebaseStore implements IStore {
 }
 
 export type Config = {
-  TakeProfit: number
-  SellAtTakeProfit: boolean
-  BuyQuantity: number
-  LossLimit: number
-  SECRET?: string
   KEY?: string
+  SECRET?: string
   PriceAsset: string
+  BuyQuantity: number
+  StopLimit: number
+  ProfitLimit: number
   SellAtStopLimit: boolean
+  SellAtProfitLimit: boolean
   SwingTradeEnabled: boolean
   PriceProvider: PriceProvider
   /**
    * When averaging down is enabled, all the money gained from selling is used to buy more your existing
    * most unprofitable (in percentage) asset.
-   * If you have assets A (+1% profit), B (-10% loss) and C(-15% loss) and A is sold, the tool will buy more
+   * If you have assets A, B (-10% loss) and C(-15% loss) and A is sold, the tool will buy more
    * of C, and C loss will be averaged down, for example to -7%.
    * Next time, if C turns profitable and is sold, the tool will buy more of B.
    * This way, **if the price decline is temporary** for all of your assets,

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -70,7 +70,8 @@ export class FirebaseStore implements IStore {
         PriceAsset: StableCoin.USDT,
         SellAtStopLimit: false,
         SwingTradeEnabled: false,
-        PriceProvider: PriceProvider.Binance
+        PriceProvider: PriceProvider.Binance,
+        AveragingDown: false,
       }
       configCache = this.getOrSet("Config", defaultConfig)
       CacheProxy.put("Config", JSON.stringify(configCache))
@@ -166,6 +167,16 @@ export type Config = {
   SellAtStopLimit: boolean
   SwingTradeEnabled: boolean
   PriceProvider: PriceProvider
+  /**
+   * When averaging down is enabled, all the money gained from selling is used to buy more your existing
+   * most unprofitable (in percentage) asset.
+   * If you have assets A (+1% profit), B (-10% loss) and C(-15% loss) and A is sold, the tool will buy more
+   * of C, and C loss will be averaged down, for example to -7%.
+   * Next time, if C turns profitable and is sold, the tool will buy more of B.
+   * This way, **if the price decline is temporary** for all of your assets,
+   * the tool will gradually sell all assets without loss.
+   */
+  AveragingDown: boolean
 }
 
 // @ts-ignore

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -109,16 +109,16 @@ export class TradeMemo {
   }
 
   lossLimitCrossedDown(): boolean {
+    // all prices except the last one are greater than the stop limit price
     const latestPrice = this.prices[this.prices.length - 1];
-    const prevPrice = this.prices[this.prices.length - 3];
-    return latestPrice < this.stopLimitPrice && prevPrice >= this.stopLimitPrice
+    return latestPrice < this.stopLimitPrice && this.prices.slice(0, -1).every(price => price >= this.stopLimitPrice)
   }
 
   profitLimitCrossedUp(profitLimit: number): boolean {
-    const latestPrice = this.prices[this.prices.length - 1];
-    const prevPrice = this.prices[this.prices.length - 3];
+    // all prices except the last one are lower the profit limit price
     const profitLimitPrice = this.tradeResult.price * (1 + profitLimit);
-    return latestPrice > profitLimitPrice && prevPrice <= profitLimitPrice
+    const latestPrice = this.prices[this.prices.length - 1];
+    return latestPrice > profitLimitPrice && this.prices.slice(0, -1).every(price => price <= profitLimitPrice)
   }
 
   priceGoesUp(lastN: number = 3): boolean {

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -8,6 +8,8 @@ export enum TradeState {
   SOLD = 'sold'
 }
 
+const PriceMemoMaxCapacity = 10;
+
 export class TradeMemo {
   tradeResult: TradeResult
   stopLossPrice: number = 0
@@ -41,6 +43,18 @@ export class TradeMemo {
 
   getKey(): TradeMemoKey {
     return new TradeMemoKey(this.tradeResult.symbol)
+  }
+
+  pushPrice(price: number): void {
+    if (price[0] === 0) {
+      // initial state, filling it with price
+      this.prices = [price, price, price];
+    } else {
+      this.prices.push(price)
+      // remove old prices and keep only the last PriceMemoMaxCapacity
+      this.prices.splice(0, this.prices.length - PriceMemoMaxCapacity)
+    }
+    this.maxObservedPrice = Math.max(this.maxObservedPrice, ...this.prices)
   }
 
   setState(state: TradeState): void {

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -1,4 +1,3 @@
-import {PriceMemo} from "./Trader";
 import {ExchangeSymbol, TradeResult} from "./TradeResult";
 
 export enum TradeState {
@@ -9,6 +8,7 @@ export enum TradeState {
 }
 
 const PriceMemoMaxCapacity = 10;
+export type PriceMemo = [number, number, number]
 
 export class TradeMemo {
   tradeResult: TradeResult
@@ -48,6 +48,10 @@ export class TradeMemo {
 
   getKey(): TradeMemoKey {
     return new TradeMemoKey(this.tradeResult.symbol)
+  }
+
+  get currentPrice(): number {
+    return this.prices[this.prices.length - 1]
   }
 
   pushPrice(price: number): void {
@@ -115,6 +119,14 @@ export class TradeMemo {
     const prevPrice = this.prices[this.prices.length - 2];
     const profitLimitPrice = this.tradeResult.price * (1 + profitLimit);
     return latestPrice > profitLimitPrice && prevPrice <= profitLimitPrice
+  }
+
+  priceGoesUp(lastN: number = 3): boolean {
+    const lastPrices = this.prices.slice(-lastN);
+    if (lastPrices[0] == 0 || lastPrices.length < lastN) {
+      return false
+    }
+    return lastPrices.every((p, i) => i == 0 ? true : p > lastPrices[i - 1])
   }
 }
 

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -110,13 +110,13 @@ export class TradeMemo {
 
   lossLimitCrossedDown(): boolean {
     const latestPrice = this.prices[this.prices.length - 1];
-    const prevPrice = this.prices[this.prices.length - 2];
+    const prevPrice = this.prices[this.prices.length - 3];
     return latestPrice < this.stopLimitPrice && prevPrice >= this.stopLimitPrice
   }
 
   profitLimitCrossedUp(profitLimit: number): boolean {
     const latestPrice = this.prices[this.prices.length - 1];
-    const prevPrice = this.prices[this.prices.length - 2];
+    const prevPrice = this.prices[this.prices.length - 3];
     const profitLimitPrice = this.tradeResult.price * (1 + profitLimit);
     return latestPrice > profitLimitPrice && prevPrice <= profitLimitPrice
   }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -4,7 +4,6 @@ import {Statistics} from "./Statistics";
 import {Config, IStore} from "./Store";
 import {ExchangeSymbol} from "./TradeResult";
 
-const PriceMemoMaxCapacity = 10;
 export type PriceMemo = [number, number, number]
 
 export class V2Trader {
@@ -30,11 +29,7 @@ export class V2Trader {
 
     const symbol = tradeMemo.tradeResult.symbol;
     const currentPrice = this.getPrice(symbol);
-
-    tradeMemo.prices.push(currentPrice)
-    // remove old prices and keep only the last PriceMemoMaxCapacity
-    tradeMemo.prices.splice(0, tradeMemo.prices.length - PriceMemoMaxCapacity)
-    tradeMemo.maxObservedPrice = Math.max(tradeMemo.maxObservedPrice, ...tradeMemo.prices)
+    tradeMemo.pushPrice(currentPrice)
 
     const priceGoesUp = this.priceGoesUp(tradeMemo.prices);
 

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -4,14 +4,13 @@ import {Statistics} from "./Statistics";
 import {Config, IStore} from "./Store";
 import {ExchangeSymbol} from "./TradeResult";
 
-export type PriceMemo = [number, number, number]
-
 export class V2Trader {
   private readonly store: IStore;
   private readonly config: Config;
   private readonly exchange: IExchange;
   private readonly stats: Statistics;
   private readonly prices: { [p: string]: number };
+  private readonly afterAll: Array<() => void> = [];
 
   constructor(store: IStore, exchange: IExchange, stats: Statistics) {
     this.store = store;
@@ -21,6 +20,16 @@ export class V2Trader {
     this.prices = exchange.getPrices()
   }
 
+  /**
+   * After ticker check can be executed after all tickers are checked.
+   * It may contain any additional operations that need to be performed after all.
+   */
+  afterTickerCheck() {
+    while (this.afterAll.length > 0) {
+      this.afterAll.pop()();
+    }
+  }
+
   tickerCheck(tradeMemo: TradeMemo): void {
 
     if (tradeMemo.stateIs(TradeState.SELL)) {
@@ -28,56 +37,21 @@ export class V2Trader {
     }
 
     const symbol = tradeMemo.tradeResult.symbol;
-    const currentPrice = this.getPrice(symbol);
-    tradeMemo.pushPrice(currentPrice)
+    tradeMemo.pushPrice(this.getPrice(symbol))
 
-    const priceGoesUp = this.priceGoesUp(tradeMemo.prices);
-
-    if (priceGoesUp) {
-      Log.info(`${symbol} price goes up`)
-    }
+    const priceGoesUp = tradeMemo.priceGoesUp()
+    priceGoesUp && Log.info(`${symbol} price goes up`)
 
     if (tradeMemo.stateIs(TradeState.BOUGHT)) {
-
-      if (tradeMemo.profitLimitCrossedUp(this.config.TakeProfit)) {
-        Log.alert(`${symbol} crossed profit limit`)
-      } else if (tradeMemo.lossLimitCrossedDown()) {
-        Log.alert(`${symbol}: crossed loss limit`)
-      }
-
-      if (currentPrice < tradeMemo.stopLimitPrice) {
-        const canSell = !tradeMemo.hodl && this.store.getConfig().SellAtStopLimit;
-        canSell && tradeMemo.setState(TradeState.SELL)
-      }
-
-      const profitLimitPrice = tradeMemo.tradeResult.price * (1 + this.config.TakeProfit);
-      if (currentPrice > profitLimitPrice) {
-        const canSell = !tradeMemo.hodl && this.store.getConfig().SellAtTakeProfit;
-        canSell && !priceGoesUp && tradeMemo.setState(TradeState.SELL)
-      }
-
-      if (priceGoesUp) {
-        // Using previous price two measures back to calculate new stop limit
-        const newStopLimit = tradeMemo.prices[tradeMemo.prices.length - 3] * (1 - this.config.LossLimit);
-        tradeMemo.stopLimitPrice = tradeMemo.stopLimitPrice < newStopLimit ? newStopLimit : tradeMemo.stopLimitPrice
-      }
+      this.processBoughtState(tradeMemo);
+    } else if (tradeMemo.stateIs(TradeState.SOLD)) {
+      this.processSoldState(tradeMemo);
     }
 
-    if (tradeMemo.stateIs(TradeState.SOLD) && this.config.SwingTradeEnabled) {
-      // Swing trade enabled.
-      // Checking if price dropped below max observed price minus take profit percentage,
-      // and we can buy again
-      const priceDropped = currentPrice < tradeMemo.maxObservedPrice * (1 - this.config.TakeProfit);
-      if (priceDropped) {
-        tradeMemo.setState(TradeState.BUY)
-        Log.alert(`${symbol} will be bought again as price dropped sufficiently`)
-      } else {
-        Log.info(`${symbol} price has not dropped sufficiently, skipping swing trade`)
-      }
-    }
-
+    // save new pushed price and any intermediate state changes
     this.store.setTrade(tradeMemo)
 
+    // take action after processing
     if (tradeMemo.stateIs(TradeState.SELL)) {
       this.sellAndClose(tradeMemo)
     } else if (tradeMemo.stateIs(TradeState.BUY) && priceGoesUp) {
@@ -85,7 +59,51 @@ export class V2Trader {
     } else {
       Log.info(`${symbol}: waiting`)
     }
+  }
 
+  private processSoldState(tm: TradeMemo): void {
+    if (!this.config.SwingTradeEnabled) {
+      return
+    }
+    // Swing trade enabled.
+    // Checking if price dropped below max observed price minus take profit percentage,
+    // and we can buy again
+    const symbol = tm.tradeResult.symbol;
+    const priceDropped = tm.currentPrice < tm.maxObservedPrice * (1 - this.config.TakeProfit);
+    if (priceDropped) {
+      Log.alert(`${symbol} will be bought again as price dropped sufficiently`)
+      tm.setState(TradeState.BUY)
+    } else {
+      Log.info(`${symbol} price has not dropped sufficiently, skipping swing trade`)
+    }
+  }
+
+  private processBoughtState(tm: TradeMemo): void {
+    const symbol = tm.tradeResult.symbol;
+    const priceGoesUp = tm.priceGoesUp()
+
+    if (tm.profitLimitCrossedUp(this.config.TakeProfit)) {
+      Log.alert(`${symbol} crossed profit limit`)
+    } else if (tm.lossLimitCrossedDown()) {
+      Log.alert(`${symbol}: crossed loss limit`)
+    }
+
+    if (tm.currentPrice < tm.stopLimitPrice) {
+      const canSell = !tm.hodl && this.store.getConfig().SellAtStopLimit;
+      canSell && tm.setState(TradeState.SELL)
+    }
+
+    const profitLimitPrice = tm.tradeResult.price * (1 + this.config.TakeProfit);
+    if (tm.currentPrice > profitLimitPrice) {
+      const canSell = !tm.hodl && this.store.getConfig().SellAtTakeProfit;
+      canSell && !priceGoesUp && tm.setState(TradeState.SELL)
+    }
+
+    if (priceGoesUp) {
+      // Using previous price two measures back to calculate new stop limit
+      const newStopLimit = tm.prices[tm.prices.length - 3] * (1 - this.config.LossLimit);
+      tm.stopLimitPrice = tm.stopLimitPrice < newStopLimit ? newStopLimit : tm.stopLimitPrice
+    }
   }
 
   private getPrice(symbol: ExchangeSymbol): number {
@@ -108,14 +126,15 @@ export class V2Trader {
   }
 
   private sellAndClose(memo: TradeMemo): void {
-    const tradeResult = this.exchange.marketSell(memo.tradeResult.symbol, memo.tradeResult.quantity);
-
+    const symbol = memo.tradeResult.symbol;
+    const tradeResult = this.exchange.marketSell(symbol, memo.tradeResult.quantity);
+    const gained = tradeResult.gained;
     if (tradeResult.fromExchange) {
       Log.debug(memo);
       const buyCommission = this.getBNBCommissionCost(memo.tradeResult.commission);
       const sellCommission = this.getBNBCommissionCost(tradeResult.commission);
       Log.info(`Commission: ~${buyCommission + sellCommission}`)
-      const profit = tradeResult.gained - memo.tradeResult.paid - sellCommission - buyCommission;
+      const profit = gained - memo.tradeResult.paid - sellCommission - buyCommission;
       tradeResult.profit = +profit.toFixed(2);
       memo.tradeResult = tradeResult;
       memo.setState(TradeState.SOLD)
@@ -123,38 +142,31 @@ export class V2Trader {
     } else {
       memo.hodl = true;
       memo.setState(TradeState.BOUGHT);
-      Log.alert(`An issue happened while selling ${memo.tradeResult.symbol}. The asset is marked HODL. Please, resolve it manually.`)
+      Log.alert(`An issue happened while selling ${symbol}. The asset is marked HODL. Please, resolve it manually.`)
     }
 
     this.store.setTrade(memo)
     Log.alert(tradeResult.toString());
 
     if (memo.stateIs(TradeState.SOLD) && this.config.AveragingDown) {
-      // all gains are reinvested to most unprofitable asset
-      // find a trade with the lowest profit percentage
-      const byProfitPercentDesc = (t1, t2) => t1.profitPercent() < t2.profitPercent() ? -1 : 1;
-      const lowestProfitTrade = this.store.getTradesList()
-        .filter(t => t.stateIs(TradeState.BOUGHT))
-        .sort(byProfitPercentDesc)[0];
-      if (lowestProfitTrade) {
-        Log.alert('Averaging down is enabled')
-        Log.alert(`All gains from selling ${memo.tradeResult.symbol} are being invested to ${lowestProfitTrade.tradeResult.symbol}`);
-        this.buy(lowestProfitTrade, tradeResult.gained);
-      }
+      this.afterAll.push(() => {
+        // all gains are reinvested to most unprofitable asset
+        // find a trade with the lowest profit percentage
+        const byProfitPercentDesc = (t1, t2) => t1.profitPercent() < t2.profitPercent() ? -1 : 1;
+        const lowestProfitTrade = this.store.getTradesList()
+          .filter(t => t.stateIs(TradeState.BOUGHT))
+          .sort(byProfitPercentDesc)[0];
+        if (lowestProfitTrade) {
+          Log.alert('Averaging down is enabled')
+          Log.alert(`All gains from selling ${symbol} are being invested to ${lowestProfitTrade.tradeResult.symbol}`);
+          this.buy(lowestProfitTrade, gained);
+        }
+      })
     }
-  }
-
-  private priceGoesUp(prices: PriceMemo, lastN: number = 3): boolean {
-    const lastPrices = prices.slice(-lastN);
-    if (lastPrices[0] == 0 || lastPrices.length < lastN) {
-      return false
-    }
-    return lastPrices.every((p, i) => i == 0 ? true : p > lastPrices[i - 1])
   }
 
   private getBNBCommissionCost(commission: number): number {
     const bnbPrice = this.prices["BNB" + this.config.PriceAsset];
     return bnbPrice ? commission * bnbPrice : 0;
   }
-
 }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -85,7 +85,7 @@ export class V2Trader {
     if (tm.profitLimitCrossedUp(this.config.TakeProfit)) {
       Log.alert(`${symbol} crossed profit limit`)
     } else if (tm.lossLimitCrossedDown()) {
-      // Log.alert(`${symbol}: crossed loss limit`)
+      Log.alert(`${symbol}: crossed loss limit`)
     }
 
     if (tm.currentPrice < tm.stopLimitPrice) {

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -85,7 +85,7 @@ export class V2Trader {
     if (tm.profitLimitCrossedUp(this.config.TakeProfit)) {
       Log.alert(`${symbol} crossed profit limit`)
     } else if (tm.lossLimitCrossedDown()) {
-      Log.alert(`${symbol}: crossed loss limit`)
+      // Log.alert(`${symbol}: crossed loss limit`)
     }
 
     if (tm.currentPrice < tm.stopLimitPrice) {

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -149,7 +149,7 @@ export class V2Trader {
       if (lowestProfitTrade) {
         Log.alert('Averaging down is enabled')
         Log.alert(`All gains from selling ${memo.tradeResult.symbol} are being invested to ${lowestProfitTrade.tradeResult.symbol}`);
-        this.buy(lowestProfitTrade, Math.floor(memo.tradeResult.gained));
+        this.buy(lowestProfitTrade, tradeResult.gained);
       }
     }
   }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -149,7 +149,7 @@ export class V2Trader {
       if (lowestProfitTrade) {
         Log.alert('Averaging down is enabled')
         Log.alert(`All gains from selling ${memo.tradeResult.symbol} are being invested to ${lowestProfitTrade.tradeResult.symbol}`);
-        this.buy(lowestProfitTrade, memo.tradeResult.gained);
+        this.buy(lowestProfitTrade, Math.floor(memo.tradeResult.gained));
       }
     }
   }

--- a/apps-script/TradesQueue.ts
+++ b/apps-script/TradesQueue.ts
@@ -41,7 +41,7 @@ export class TradesQueue {
           const trade = store.getTrade(symbol) || new TradeMemo(new TradeResult(symbol));
           trade.setState(TradeState.BUY);
           store.setTrade(trade);
-        } else if (action === QueueAction.NOT_BUY) {
+        } else if (action === QueueAction.CANCEL) {
           const trade = store.getTrade(symbol);
           if (trade) {
             if (trade.tradeResult.quantity) {
@@ -88,16 +88,16 @@ export class TradesQueue {
     CacheProxy.put('Queue', JSON.stringify(queue));
   }
 
-  static cancelBuy(coinName: string) {
+  static cancelAction(coinName: string) {
     const queue = this.getQueue();
-    queue[coinName] = QueueAction.NOT_BUY;
+    queue[coinName] = QueueAction.CANCEL;
     CacheProxy.put('Queue', JSON.stringify(queue));
   }
 }
 
 enum QueueAction {
   BUY = 'BUY',
-  NOT_BUY = 'NOT_BUY',
+  CANCEL = 'CANCEL',
   SELL = 'SELL',
   HOLD = 'HOLD',
   NOT_HOLD = 'NOT_HOLD',

--- a/apps-script/Watcher.ts
+++ b/apps-script/Watcher.ts
@@ -41,6 +41,12 @@ function Ticker() {
     }
   })
 
+  try {
+    trader.afterTickerCheck();
+  } catch (e) {
+    Log.error(e)
+  }
+
   store.dumpChanges();
 
   Log.ifUsefulDumpAsEmail()

--- a/apps-script/api.ts
+++ b/apps-script/api.ts
@@ -64,12 +64,12 @@ function buyCoin(coinName: string) {
   });
 }
 
-function cancelBuy(coinName: string) {
+function cancelAction(coinName: string) {
   return catchError(() => {
     if (coinName) {
-      Log.info("Cancelling buying of " + coinName);
-      TradesQueue.cancelBuy(coinName);
-      return "Requested to cancel buying of " + coinName;
+      Log.info("Cancelling the action on " + coinName);
+      TradesQueue.cancelAction(coinName);
+      return "Requested to cancel an action on " + coinName;
     }
     return "No coinName specified";
   });

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -26,7 +26,7 @@ export function Info() {
     });
 
   return (
-    <div style={{height: 400, width: '100%'}}>
+    <div style={{height: `${window.visualViewport.height - 97}px`, width: '100%'}}>
       <DataGrid
         rows={rows}
         columns={columns}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,31 +12,31 @@ export function Settings() {
 
   const [config, setConfig] = useState<Config>({
     BuyQuantity: 0,
-    LossLimit: 0,
+    StopLimit: 0,
     PriceAsset: "",
     SellAtStopLimit: false,
-    SellAtTakeProfit: false,
-    TakeProfit: 0,
+    SellAtProfitLimit: false,
+    ProfitLimit: 0,
     SwingTradeEnabled: false,
     PriceProvider: PriceProvider.Binance,
     AveragingDown: false,
   });
 
-  const [lossLimit, setLossLimit] = useState('');
-  const [takeProfit, setTakeProfit] = useState('');
+  const [stopLimit, setLossLimit] = useState('');
+  const [profitLimit, setProfitLimit] = useState('');
   const [buyQuantity, setBuyQuantity] = useState('');
 
   // @ts-ignore
   useEffect(() => google.script.run.withSuccessHandler(config => {
-    setLossLimit((+(config.LossLimit * 100).toFixed(2)).toString());
-    setTakeProfit((+(config.TakeProfit * 100).toFixed(2)).toString());
+    setLossLimit((+(config.StopLimit * 100).toFixed(2)).toString());
+    setProfitLimit((+(config.ProfitLimit * 100).toFixed(2)).toString());
     setBuyQuantity(config.BuyQuantity.toString());
     setConfig(config);
   }).getConfig(), [])
 
   const onSave = () => {
-    isFinite(+lossLimit) && (config.LossLimit = +lossLimit / 100);
-    isFinite(+takeProfit) && (config.TakeProfit = +takeProfit / 100);
+    isFinite(+stopLimit) && (config.StopLimit = +stopLimit / 100);
+    isFinite(+profitLimit) && (config.ProfitLimit = +profitLimit / 100);
     isFinite(+buyQuantity) && (config.BuyQuantity = Math.floor(+buyQuantity));
     setConfig(config);
     setIsSaving(true);
@@ -63,19 +63,19 @@ export function Settings() {
                    InputProps={{startAdornment: <InputAdornment position="start">$</InputAdornment>}}
         />
         <Stack direction="row" spacing={2}>
-          <TextField value={takeProfit} label={"Profit Limit"} onChange={e => setTakeProfit(e.target.value)}
+          <TextField value={profitLimit} label={"Profit Limit"} onChange={e => setProfitLimit(e.target.value)}
                      InputProps={{startAdornment: <InputAdornment position="start">%</InputAdornment>}}
           />
           <FormControlLabel
             control={
-              <Switch checked={config.SellAtTakeProfit}
-                      onChange={e => setConfig({...config, SellAtTakeProfit: e.target.checked})}/>
+              <Switch checked={config.SellAtProfitLimit}
+                      onChange={e => setConfig({...config, SellAtProfitLimit: e.target.checked})}/>
             }
             label="Auto-sell"
           />
         </Stack>
         <Stack direction="row" spacing={2}>
-          <TextField value={lossLimit} label={"Loss Limit"} onChange={e => setLossLimit(e.target.value)}
+          <TextField value={stopLimit} label={"Stop Limit"} onChange={e => setLossLimit(e.target.value)}
                      InputProps={{startAdornment: <InputAdornment position="start">%</InputAdornment>}}
           />
           <FormControlLabel

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -26,14 +26,13 @@ export function Settings() {
   const [takeProfit, setTakeProfit] = useState('');
   const [buyQuantity, setBuyQuantity] = useState('');
 
-  useEffect(() => {
+  // @ts-ignore
+  useEffect(() => google.script.run.withSuccessHandler(config => {
     setLossLimit((+(config.LossLimit * 100).toFixed(2)).toString());
     setTakeProfit((+(config.TakeProfit * 100).toFixed(2)).toString());
     setBuyQuantity(config.BuyQuantity.toString());
-  }, [config]);
-
-  // @ts-ignore
-  useEffect(() => google.script.run.withSuccessHandler(setConfig).getConfig(), [])
+    setConfig(config);
+  }).getConfig(), [])
 
   const onSave = () => {
     isFinite(+lossLimit) && (config.LossLimit = +lossLimit / 100);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -19,6 +19,7 @@ export function Settings() {
     TakeProfit: 0,
     SwingTradeEnabled: false,
     PriceProvider: PriceProvider.Binance,
+    AveragingDown: false,
   });
 
   const [lossLimit, setLossLimit] = useState('');
@@ -89,7 +90,14 @@ export function Settings() {
             <Switch checked={config.SwingTradeEnabled}
                     onChange={e => setConfig({...config, SwingTradeEnabled: e.target.checked})}/>
           }
-          label="Swing trade"
+          label="Swing trading"
+        />
+        <FormControlLabel
+          control={
+            <Switch checked={config.AveragingDown}
+                    onChange={e => setConfig({...config, AveragingDown: e.target.checked})}/>
+          }
+          label="Averaging down"
         />
         <Stack direction={"row"}>
           <Box sx={{position: 'relative'}}>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -24,10 +24,12 @@ export function Settings() {
 
   const [lossLimit, setLossLimit] = useState('');
   const [takeProfit, setTakeProfit] = useState('');
+  const [buyQuantity, setBuyQuantity] = useState('');
 
   useEffect(() => {
     setLossLimit((+(config.LossLimit * 100).toFixed(2)).toString());
     setTakeProfit((+(config.TakeProfit * 100).toFixed(2)).toString());
+    setBuyQuantity(config.BuyQuantity.toString());
   }, [config]);
 
   // @ts-ignore
@@ -36,6 +38,7 @@ export function Settings() {
   const onSave = () => {
     isFinite(+lossLimit) && (config.LossLimit = +lossLimit / 100);
     isFinite(+takeProfit) && (config.TakeProfit = +takeProfit / 100);
+    isFinite(+buyQuantity) && (config.BuyQuantity = Math.floor(+buyQuantity));
     setConfig(config);
     setIsSaving(true);
     // @ts-ignore
@@ -57,8 +60,7 @@ export function Settings() {
         <TextField value={config.PriceAsset} label={"Stable Coin"}
                    onChange={e => setConfig({...config, PriceAsset: e.target.value})}
         />
-        <TextField value={config.BuyQuantity} label={"Buy Quantity"}
-                   onChange={e => setConfig({...config, BuyQuantity: +e.target.value})}
+        <TextField value={buyQuantity} label={"Buy Quantity"} onChange={e => setBuyQuantity(e.target.value)}
                    InputProps={{startAdornment: <InputAdornment position="start">$</InputAdornment>}}
         />
         <Stack direction="row" spacing={2}>

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -74,28 +74,27 @@ export default function Trade(props) {
 
     if (limitLine) {
       limitLine.applyOptions({
-        visible: !!tm.stopLossPrice,
+        visible: !!tm.tradeResult.quantity,
         // make dashed if config SellAtStopLimit is false or HODLing
         lineStyle: !config.SellAtStopLimit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
       });
       limitLine.setData(map(tm.prices, () => tm.stopLossPrice))
     }
 
-    const orderPrice = tm.tradeResult.price;
-
     if (orderLine) {
-      orderLine.applyOptions({visible: !!orderPrice});
-      orderLine.setData(map(tm.prices, () => orderPrice))
+      orderLine.applyOptions({visible: !!tm.tradeResult.quantity});
+      orderLine.setData(map(tm.prices, () => tm.tradeResult.price))
     }
 
     if (profitLine) {
       profitLine.applyOptions({
-        visible: !!orderPrice && !tm.stateIs(TradeState.SOLD),
+        visible: !!tm.tradeResult.quantity,
         color: profitLineColor,
         // make dashed if config SellAtTakeProfit is false or HODLing
         lineStyle: !config.SellAtTakeProfit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
       });
-      profitLine.setData(map(tm.prices, () => orderPrice * (1 + config.TakeProfit)))
+      const profitPrice = tm.tradeResult.price * (1 + config.TakeProfit);
+      profitLine.setData(map(tm.prices, () => profitPrice))
     }
 
     if (soldPriceLine) {
@@ -189,11 +188,13 @@ export default function Trade(props) {
             <Typography gutterBottom variant="h5" component="div">{props.name}</Typography>
             <Box width={chartOpts.width} height={chartOpts.height} ref={chartContainerRef} className="chart-container"/>
           </CardContent>
-          <Typography marginLeft={"16px"} variant="body2" color="text.secondary">
-            <div>Qty: {tm.tradeResult.quantity} Paid: {tm.tradeResult.paid.toFixed(2)}</div>
-            <div>{tm.profit() >= 0 ? "Profit" : "Loss"}: {f2(tm.profit())} ({f2(tm.profitPercent())}%)</div>
-            <div>Stop: {f2(tm.stopLimitLoss())} ({f2(tm.stopLimitLossPercent())}%)</div>
-          </Typography>
+          {tm.tradeResult.quantity &&
+            <Typography marginLeft={"16px"} variant="body2" color="text.secondary">
+              <div>Qty: {tm.tradeResult.quantity} Paid: {tm.tradeResult.paid.toFixed(2)}</div>
+              <div>{tm.profit() >= 0 ? "Profit" : "Loss"}: {f2(tm.profit())} ({f2(tm.profitPercent())}%)</div>
+              <div>Stop: {f2(tm.stopLimitLoss())} ({f2(tm.stopLimitLossPercent())}%)</div>
+            </Typography>
+          }
           <CardActions>
             <Stack direction={"row"} spacing={1}>
               {tm.stateIs(TradeState.BOUGHT) &&

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -188,7 +188,7 @@ export default function Trade(props) {
             <Typography gutterBottom variant="h5" component="div">{props.name}</Typography>
             <Box width={chartOpts.width} height={chartOpts.height} ref={chartContainerRef} className="chart-container"/>
           </CardContent>
-          {tm.tradeResult.quantity &&
+          {!!tm.tradeResult.quantity &&
             <Typography marginLeft={"16px"} variant="body2" color="text.secondary">
               <div>Qty: {tm.tradeResult.quantity} Paid: {tm.tradeResult.paid.toFixed(2)}</div>
               <div>{tm.profit() >= 0 ? "Profit" : "Loss"}: {f2(tm.profit())} ({f2(tm.profitPercent())}%)</div>

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -90,10 +90,10 @@ export default function Trade(props) {
       profitLine.applyOptions({
         visible: !!tm.tradeResult.quantity,
         color: profitLineColor,
-        // make dashed if config SellAtTakeProfit is false or HODLing
-        lineStyle: !config.SellAtTakeProfit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
+        // make dashed if config SellAtProfitLimit is false or HODLing
+        lineStyle: !config.SellAtProfitLimit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
       });
-      const profitPrice = tm.tradeResult.price * (1 + config.TakeProfit);
+      const profitPrice = tm.tradeResult.price * (1 + config.ProfitLimit);
       profitLine.setData(map(tm.prices, () => profitPrice))
     }
 

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -132,16 +132,16 @@ export default function Trade(props) {
     }
   }
 
-  const [buyCanceled, setBuyCanceled] = useState(false);
+  const [actionCanceled, setActionCanceled] = useState(false);
 
-  function onCancelBuy() {
-    if (confirm(`Are you sure you want to cancel buying ${props.name}?`)) {
+  function onCancel() {
+    if (confirm(`Are you sure you want to cancel the action on ${props.name}?`)) {
       const handle = resp => {
         alert(resp.toString());
-        setBuyCanceled(true);
+        setActionCanceled(true);
       };
       // @ts-ignore
-      google.script.run.withSuccessHandler(handle).withFailureHandler(alert).cancelBuy(props.name);
+      google.script.run.withSuccessHandler(handle).withFailureHandler(alert).cancelAction(props.name);
     }
   }
 
@@ -214,8 +214,8 @@ export default function Trade(props) {
               {tm.stateIs(TradeState.SOLD) &&
                 <Button size="small" disabled={isRemoving} onClick={onRemove}>{isRemoving ? '...' : 'Remove'}</Button>
               }
-              {tm.stateIs(TradeState.BUY) &&
-                <Button size="small" disabled={buyCanceled} onClick={onCancelBuy}>Cancel</Button>
+              {[TradeState.BUY, TradeState.SELL].includes(tm.getState()) &&
+                <Button size="small" disabled={actionCanceled} onClick={onCancel}>Cancel</Button>
               }
             </Stack>
           </CardActions>

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -78,7 +78,7 @@ export default function Trade(props) {
         // make dashed if config SellAtStopLimit is false or HODLing
         lineStyle: !config.SellAtStopLimit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
       });
-      limitLine.setData(map(tm.prices, () => tm.stopLossPrice))
+      limitLine.setData(map(tm.prices, () => tm.stopLimitPrice))
     }
 
     if (orderLine) {

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -107,7 +107,7 @@ export default function Trade(props) {
   const [isSelling, setIsSelling] = useState(false);
 
   function onSell() {
-    if (confirm(`Are you sure you want to sell ${props.name}?`)) {
+    if (confirm(`Are you sure you want to sell ${props.name}? ${config.AveragingDown ? "Averaging down is enabled. All gained money will be re-invested to the most unprofitable coin." : ""}`)) {
       setIsSelling(true);
       const handle = resp => {
         alert(resp.toString());

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -121,7 +121,7 @@ export default function Trade(props) {
   const [isBuying, setIsBuying] = useState(false);
 
   function onBuy() {
-    if (confirm(`Are you sure you want to buy more ${props.name}?`)) {
+    if (confirm(`Are you sure you want to buy ${props.name}?`)) {
       setIsBuying(true);
       const handle = resp => {
         alert(resp.toString());


### PR DESCRIPTION
## Change log

* Added "Averaging Down" feature
* Fixed #8 
* Other improvements under the hood

```
/**
   * When averaging down is enabled, all the money gained from selling is used to buy more your existing
   * most unprofitable (in percentage) asset.
   * If you have assets A, B (-10% loss) and C(-15% loss) and A is sold, the tool will buy more
   * of C, and C loss will be averaged down, for example to -7%.
   * Next time, if C turns profitable and is sold, the tool will buy more of B.
   * This way, **if the price decline is temporary** for all of your assets,
   * the tool will gradually sell all assets without loss.
   */
   ```