### PR TITLE
Feature: Price anomaly alert

### DIFF
--- a/apps-script/Binance.ts
+++ b/apps-script/Binance.ts
@@ -25,7 +25,7 @@ export class Binance implements IExchange, IPriceProvider {
   }
 
   getPrices(): PriceMap {
-    Log.info("Fetching prices from Binance")
+    Log.debug("Fetching prices from Binance")
     try {
       const prices: { symbol: string, price: string }[] = this.fetch(() => "ticker/price", this.defaultReqOpts);
       Log.debug(`Got ${prices.length} prices`)

--- a/apps-script/Common.ts
+++ b/apps-script/Common.ts
@@ -80,3 +80,8 @@ function sumWithMaxPrecision(a: number, b: number): number {
 function getRandomFromList(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
+
+function absPercentageChange(v1: number, v2: number): number {
+  // |100 x (v2 - v1) / |v1||
+  return +Math.abs(100 * (v2 - v1) / Math.abs(v1)).toFixed(2)
+}

--- a/apps-script/PriceAnomalyChecker.ts
+++ b/apps-script/PriceAnomalyChecker.ts
@@ -1,5 +1,5 @@
-import {TradeMemo} from "./TradeMemo";
-import {CacheProxy} from "./CacheProxy";
+import { TradeMemo } from './TradeMemo'
+import { CacheProxy } from './CacheProxy'
 
 export enum PriceAnomaly {
   NONE,
@@ -22,8 +22,8 @@ export class PriceAnomalyChecker {
     const pump = changeIndex >= (TradeMemo.PriceMemoMaxCapacity - 1) * strength;
 
     if (pump || dump) {
-      Log.alert(`${tm.getCoinName()} price anomaly detected`)
-      CacheProxy.put(key, anomalyStartPrice || tm.prices[0].toString(), 120); // 2 minutes
+      Log.debug(`${tm.getCoinName()} price anomaly detected`)
+      CacheProxy.put(key, anomalyStartPrice || tm.prices[0].toString(), 120) // 2 minutes
     }
 
     if (!anomalyStartPrice) {

--- a/apps-script/PriceAnomalyChecker.ts
+++ b/apps-script/PriceAnomalyChecker.ts
@@ -1,0 +1,52 @@
+import {TradeMemo} from "./TradeMemo";
+import {CacheProxy} from "./CacheProxy";
+
+export enum PriceAnomaly {
+  NONE,
+  PUMP,
+  DUMP,
+}
+
+export class PriceAnomalyChecker {
+  public static check(tm: TradeMemo, pdAlertPercentage: number): PriceAnomaly {
+    if (tm.prices.length < TradeMemo.PriceMemoMaxCapacity) {
+      return PriceAnomaly.NONE;
+    }
+
+    const key = `${tm.getCoinName()}-pump-dump-start`;
+    const changeIndex = tm.getPriceChangeIndex(tm.prices.slice(-TradeMemo.PriceMemoMaxCapacity));
+    const anomalyStartPrice = CacheProxy.get(key);
+
+    const strength = 0.8;
+    const dump = changeIndex <= -(TradeMemo.PriceMemoMaxCapacity - 1) * strength;
+    const pump = changeIndex >= (TradeMemo.PriceMemoMaxCapacity - 1) * strength;
+
+    if (pump || dump) {
+      Log.alert(`${tm.getCoinName()} price anomaly detected`)
+      CacheProxy.put(key, anomalyStartPrice || tm.prices[0].toString(), 120); // 2 minutes
+    }
+
+    if (!anomalyStartPrice) {
+      return PriceAnomaly.NONE;
+    }
+
+    CacheProxy.remove(key);
+    const percent = absPercentageChange(+anomalyStartPrice, tm.currentPrice)
+
+    if (percent < pdAlertPercentage) {
+      return PriceAnomaly.NONE
+    }
+
+    if (+anomalyStartPrice > tm.currentPrice) {
+      Log.alert(`${tm.getCoinName()} price dumped for ${percent}%: ${anomalyStartPrice} -> ${tm.currentPrice}`);
+      return PriceAnomaly.DUMP
+    }
+
+    if (+anomalyStartPrice < tm.currentPrice) {
+      Log.alert(`${tm.getCoinName()} price pumped for ${percent}%: ${anomalyStartPrice} -> ${tm.currentPrice}`);
+      return PriceAnomaly.PUMP
+    }
+
+    return PriceAnomaly.NONE
+  }
+}

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -66,7 +66,7 @@ export class FirebaseStore implements IStore {
       PriceProvider: PriceProvider.Binance,
       AveragingDown: false,
       ProfitBasedStopLimit: false,
-      DumpAlertPercentage: 5
+      PriceAnomalyAlert: 5
     }
     const configCacheJson = CacheProxy.get("Config");
     let configCache: Config = configCacheJson ? JSON.parse(configCacheJson) : null;
@@ -245,11 +245,11 @@ export type Config = {
    */
   AveragingDown: boolean
   /**
-   * When price suddenly drops for more than or equal percentage - an alert is sent.
+   * When price suddenly pumps or dumps for more than or equal percentage - an alert is sent.
    */
-  DumpAlertPercentage?: number;
+  PriceAnomalyAlert?: number;
   /**
-   * If true - buy the price dump automatically when {@link DumpAlertPercentage} alert happens.
+   * If true - buy the price dump automatically when {@link PriceAnomalyAlert} alert happens.
    */
   BuyDumps?: boolean;
 

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -55,23 +55,26 @@ export class FirebaseStore implements IStore {
   }
 
   getConfig(): Config {
+    const defaultConfig: Config = {
+      BuyQuantity: 10,
+      StableCoin: StableUSDCoin.USDT,
+      StopLimit: 0.05,
+      ProfitLimit: 0.1,
+      SellAtStopLimit: false,
+      SellAtProfitLimit: true,
+      SwingTradeEnabled: false,
+      PriceProvider: PriceProvider.Binance,
+      AveragingDown: false,
+      ProfitBasedStopLimit: false,
+      DipAlertPercentage: 5
+    }
     const configCacheJson = CacheProxy.get("Config");
     let configCache: Config = configCacheJson ? JSON.parse(configCacheJson) : null;
     if (!configCache) {
-      const defaultConfig: Config = {
-        BuyQuantity: 10,
-        StableCoin: StableUSDCoin.USDT,
-        StopLimit: 0.05,
-        ProfitLimit: 0.1,
-        SellAtStopLimit: false,
-        SellAtProfitLimit: true,
-        SwingTradeEnabled: false,
-        PriceProvider: PriceProvider.Binance,
-        AveragingDown: false,
-        ProfitBasedStopLimit: false
-      }
       configCache = this.getOrSet("Config", defaultConfig)
     }
+    // apply existing config on top of default one
+    configCache = Object.assign(defaultConfig, configCache)
 
     if (configCache.TakeProfit) {
       configCache.ProfitLimit = configCache.TakeProfit
@@ -241,6 +244,10 @@ export type Config = {
    * the tool will gradually sell all assets without loss.
    */
   AveragingDown: boolean
+  /**
+   * When price suddenly drops for more than or equal percentage - an alert is sent.
+   */
+  DipAlertPercentage?: number;
 
   /**
    * @deprecated

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -66,7 +66,7 @@ export class FirebaseStore implements IStore {
       PriceProvider: PriceProvider.Binance,
       AveragingDown: false,
       ProfitBasedStopLimit: false,
-      DipAlertPercentage: 5
+      DumpAlertPercentage: 5
     }
     const configCacheJson = CacheProxy.get("Config");
     let configCache: Config = configCacheJson ? JSON.parse(configCacheJson) : null;
@@ -247,11 +247,11 @@ export type Config = {
   /**
    * When price suddenly drops for more than or equal percentage - an alert is sent.
    */
-  DipAlertPercentage?: number;
+  DumpAlertPercentage?: number;
   /**
-   * If true - buy the dip automatically when {@link DipAlertPercentage} alert happens.
+   * If true - buy the price dump automatically when {@link DumpAlertPercentage} alert happens.
    */
-  BuyDips?: boolean;
+  BuyDumps?: boolean;
 
   /**
    * @deprecated

--- a/apps-script/Store.ts
+++ b/apps-script/Store.ts
@@ -248,6 +248,10 @@ export type Config = {
    * When price suddenly drops for more than or equal percentage - an alert is sent.
    */
   DipAlertPercentage?: number;
+  /**
+   * If true - buy the dip automatically when {@link DipAlertPercentage} alert happens.
+   */
+  BuyDips?: boolean;
 
   /**
    * @deprecated

--- a/apps-script/TradeActions.ts
+++ b/apps-script/TradeActions.ts
@@ -29,11 +29,8 @@ export class TradeActions {
 
   static drop(coinName: string): void {
     DefaultStore.changeTrade(coinName, trade => {
-      if (trade.stateIs(TradeState.SOLD) || trade.stateIs(TradeState.BUY)) {
-        trade.deleted = true;
-        return trade;
-      }
-      Log.error(new Error(`Cannot drop ${coinName} as it is not sold`));
+      trade.deleted = true;
+      return trade;
     });
   }
 

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -152,13 +152,19 @@ export class TradeMemo {
 
   lossLimitCrossedDown(): boolean {
     // all prices except the last one are greater than the stop limit price
-    return this.currentPrice < this.stopLimitPrice && this.prices.slice(0, -1).every(price => price >= this.stopLimitPrice)
+    return this.currentPrice < this.stopLimitPrice && this.prices.slice(0, -1).every(p => p >= this.stopLimitPrice)
   }
 
   profitLimitCrossedUp(profitLimit: number): boolean {
     // all prices except the last one are lower the profit limit price
     const profitLimitPrice = this.tradeResult.price * (1 + profitLimit);
-    return this.currentPrice > profitLimitPrice && this.prices.slice(0, -1).every(price => price <= profitLimitPrice)
+    return this.currentPrice > profitLimitPrice && this.prices.slice(0, -1).every(p => p <= profitLimitPrice)
+  }
+
+  entryPriceCrossedUp() {
+    // all prices except the last one are lower the price at which the trade was bought
+    const entryPrice = this.tradeResult.price;
+    return this.currentPrice > entryPrice && this.prices.slice(0, -1).every(p => p <= entryPrice)
   }
 
   priceGoesUp(lastN: number = 3): boolean {

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -171,7 +171,7 @@ export class TradeMemo {
     const tail = this.prices.slice(-lastN);
     if (tail.length < lastN) return false;
     // returns true if all prices in the tail are increasing
-    return this.getGrowthIndex(tail) === tail.length - 1;
+    return this.getPriceChangeIndex(tail) === tail.length - 1;
   }
 
   /**
@@ -185,7 +185,7 @@ export class TradeMemo {
    * @example [1, 2, 3] => 2
    * @param prices
    */
-  getGrowthIndex(prices: number[]): number {
+  getPriceChangeIndex(prices: number[]): number {
     let result = 0;
     for (let j = prices.length - 1; j > 0; j--) {
       if (prices[j] > prices[j - 1]) {

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -7,10 +7,11 @@ export enum TradeState {
   SOLD = 'sold'
 }
 
-const PriceMemoMaxCapacity = 10;
 export type PriceMemo = [number, number, number]
 
 export class TradeMemo {
+  static readonly PriceMemoMaxCapacity = 10;
+
   tradeResult: TradeResult
   /**
    * Keeps the latest measures of the asset price.
@@ -95,7 +96,7 @@ export class TradeMemo {
     } else {
       this.prices.push(price)
       // remove old prices and keep only the last PriceMemoMaxCapacity
-      this.prices.splice(0, this.prices.length - PriceMemoMaxCapacity)
+      this.prices.splice(0, this.prices.length - TradeMemo.PriceMemoMaxCapacity)
     }
     this.maxObservedPrice = Math.max(this.maxObservedPrice, ...this.prices)
   }

--- a/apps-script/TradeMemo.ts
+++ b/apps-script/TradeMemo.ts
@@ -90,9 +90,9 @@ export class TradeMemo {
   }
 
   pushPrice(price: number): void {
-    if (this.prices[0] === 0) {
-      // initial state, filling it with price
-      this.prices = [price, price, price];
+    if (!this.prices || !this.prices.length || this.prices[0] === 0) {
+      // initial state, filling PriceMemoMaxCapacity with price
+      this.prices = new Array(TradeMemo.PriceMemoMaxCapacity).fill(price) as PriceMemo
     } else {
       this.prices.push(price)
       // remove old prices and keep only the last PriceMemoMaxCapacity

--- a/apps-script/TradeResult.ts
+++ b/apps-script/TradeResult.ts
@@ -59,7 +59,7 @@ export class TradeResult {
    * @example "Bought 21 DAR for 9.81183 BUSD. Average price: 0.46723"
    */
   toTradeString(): string {
-    return `${this.soldPrice ? 'Sold' : 'Bought'} ${this.quantity} ${this.symbol.quantityAsset} for ${this.cost} ${this.symbol.priceAsset}. Average price: ${this.price}`
+    return `${this.soldPrice ? 'Sold' : 'Bought'} ${this.quantity} ${this.symbol.quantityAsset} for ${this.cost} ${this.symbol.priceAsset}. Price: ${this.price}`
   }
 
   join(next: TradeResult): TradeResult {

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -261,7 +261,7 @@ export class V2Trader {
       CacheProxy.put(key, dipStartPrice || tm.prices[0].toString(), 120); // 2 minutes
     } else if (dipStartPrice) {
       const dipPercent = 100 * (1 - tm.currentPrice / +dipStartPrice)
-      Log.alert(`${dipPercent.toFixed(2)}% ${tm.getCoinName()} price dip: ${dipStartPrice} -> ${tm.currentPrice}`);
+      Log.alert(`-${dipPercent.toFixed(2)}% ${tm.getCoinName()} price dip: ${dipStartPrice} -> ${tm.currentPrice}`);
       CacheProxy.remove(key);
     }
   }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -84,15 +84,7 @@ export class V2Trader {
   }
 
   private processBoughtState(tm: TradeMemo): void {
-    const symbol = tm.tradeResult.symbol;
-
-    if (tm.profitLimitCrossedUp(this.config.ProfitLimit)) {
-      Log.alert(`${symbol} profit limit crossed up at ${tm.currentPrice}`)
-    } else if (tm.lossLimitCrossedDown()) {
-      Log.alert(`${symbol} stop limit crossed down at ${tm.currentPrice}`)
-    } else if (tm.entryPriceCrossedUp()) {
-      Log.alert(`${symbol} entry price crossed up at ${tm.currentPrice}`)
-    }
+    this.sendLevelsCrossingAlerts(tm);
 
     if (tm.currentPrice < tm.stopLimitPrice) {
       const canSell = !tm.hodl && this.store.getConfig().SellAtStopLimit;
@@ -112,6 +104,19 @@ export class V2Trader {
       // Using the previous price a few measures back to calculate new stop limit
       const newStopLimit = tm.prices[tm.prices.length - 3] * (1 - this.config.StopLimit);
       tm.stopLimitPrice = Math.max(tm.stopLimitPrice, newStopLimit);
+    }
+  }
+
+  private sendLevelsCrossingAlerts(tm: TradeMemo) {
+    const symbol = tm.tradeResult.symbol;
+    if (!tm.hodl) {
+      if (tm.profitLimitCrossedUp(this.config.ProfitLimit)) {
+        Log.alert(`${symbol} profit limit crossed up at ${tm.currentPrice}`)
+      } else if (tm.lossLimitCrossedDown()) {
+        Log.alert(`${symbol} stop limit crossed down at ${tm.currentPrice}`)
+      } else if (tm.entryPriceCrossedUp()) {
+        Log.alert(`${symbol} entry price crossed up at ${tm.currentPrice}`)
+      }
     }
   }
 

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -148,6 +148,7 @@ export class V2Trader {
     if (tradeResult.fromExchange) {
       this.processBuyFee(tradeResult);
       tm.joinWithNewTrade(tradeResult);
+      Log.alert(`${tm.getCoinName()} asset average price: ${tm.tradeResult.price}`)
       Log.debug(tm);
     } else {
       Log.alert(`${symbol.quantityAsset} could not be bought: ${tradeResult}`)

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -260,8 +260,8 @@ export class V2Trader {
     if (growthIndex + TradeMemo.PriceMemoMaxCapacity <= 2) {
       CacheProxy.put(key, dipStartPrice || tm.prices[0].toString(), 120); // 2 minutes
     } else if (dipStartPrice) {
-      const percentage = 100 * (tm.currentPrice / +dipStartPrice)
-      Log.alert(`${percentage.toFixed(2)} dip in ${tm.getCoinName()} price: ${dipStartPrice} -> ${tm.currentPrice}`);
+      const dipPercent = 100 * (1 - tm.currentPrice / +dipStartPrice)
+      Log.alert(`${dipPercent.toFixed(2)}% ${tm.getCoinName()} price dip: ${dipStartPrice} -> ${tm.currentPrice}`);
       CacheProxy.remove(key);
     }
   }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -1,17 +1,17 @@
-import {TradeMemo, TradeState} from "./TradeMemo";
-import {Statistics} from "./Statistics";
-import {Config, DefaultStore, IStore} from "./Store";
-import {IExchange} from "./Exchange";
-import {ExchangeSymbol, TradeResult} from "./TradeResult";
-import {Coin, PriceMap, StableUSDCoin} from "./shared-lib/types";
-import {CacheProxy} from "./CacheProxy";
+import { TradeMemo, TradeState } from './TradeMemo'
+import { Statistics } from './Statistics'
+import { Config, DefaultStore, IStore } from './Store'
+import { IExchange } from './Exchange'
+import { ExchangeSymbol, TradeResult } from './TradeResult'
+import { Coin, PriceMap, StableUSDCoin } from './shared-lib/types'
+import { CacheProxy } from './CacheProxy'
 
 export class V2Trader {
-  private readonly store: IStore;
-  private readonly config: Config;
-  private readonly exchange: IExchange;
-  private readonly stats: Statistics;
-  private readonly prices: PriceMap;
+  private readonly store: IStore
+  private readonly config: Config
+  private readonly exchange: IExchange
+  private readonly stats: Statistics
+  private readonly prices: PriceMap
 
   /**
    * Used when {@link Config.ProfitBasedStopLimit} is enabled.
@@ -42,9 +42,6 @@ export class V2Trader {
       if (this.isPriceDump(tm) && tm.stateIs(TradeState.BOUGHT) && this.config.BuyDumps) {
         Log.alert(`Buying price dumps is enabled: more ${tm.getCoinName()} will be bought.`)
         tm.setState(TradeState.BUY);
-        // todo: temporary measure to buy once
-        this.config.BuyDumps = false;
-        this.store.setConfig(this.config);
       }
     }
 

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -257,7 +257,7 @@ export class V2Trader {
     const growthIndex = tm.getGrowthIndex(tm.prices.slice(-TradeMemo.PriceMemoMaxCapacity));
     const dipStartPrice = CacheProxy.get(key);
 
-    if (growthIndex + TradeMemo.PriceMemoMaxCapacity <= 2) {
+    if (growthIndex + TradeMemo.PriceMemoMaxCapacity <= 3) {
       CacheProxy.put(key, dipStartPrice || tm.prices[0].toString(), 120); // 2 minutes
     } else if (dipStartPrice) {
       const dipPercent = 100 * (1 - tm.currentPrice / +dipStartPrice)

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -87,9 +87,11 @@ export class V2Trader {
     const symbol = tm.tradeResult.symbol;
 
     if (tm.profitLimitCrossedUp(this.config.ProfitLimit)) {
-      Log.alert(`${symbol} crossed profit limit at ${tm.currentPrice}`)
+      Log.alert(`${symbol} profit limit crossed up at ${tm.currentPrice}`)
     } else if (tm.lossLimitCrossedDown()) {
-      Log.alert(`${symbol}: crossed stop limit at ${tm.currentPrice}`)
+      Log.alert(`${symbol} stop limit crossed down at ${tm.currentPrice}`)
+    } else if (tm.entryPriceCrossedUp()) {
+      Log.alert(`${symbol} entry price crossed up at ${tm.currentPrice}`)
     }
 
     if (tm.currentPrice < tm.stopLimitPrice) {

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -261,7 +261,9 @@ export class V2Trader {
       CacheProxy.put(key, dipStartPrice || tm.prices[0].toString(), 120); // 2 minutes
     } else if (dipStartPrice) {
       const dipPercent = 100 * (1 - tm.currentPrice / +dipStartPrice)
-      Log.alert(`-${dipPercent.toFixed(2)}% ${tm.getCoinName()} price dip: ${dipStartPrice} -> ${tm.currentPrice}`);
+      if (dipPercent >= this.config.DipAlertPercentage) {
+        Log.alert(`-${dipPercent.toFixed(2)}% ${tm.getCoinName()} price dip: ${dipStartPrice} -> ${tm.currentPrice}`);
+      }
       CacheProxy.remove(key);
     }
   }

--- a/apps-script/Trader.ts
+++ b/apps-script/Trader.ts
@@ -1,10 +1,10 @@
-import { TradeMemo, TradeState } from './TradeMemo'
-import { Statistics } from './Statistics'
-import { Config, DefaultStore, IStore } from './Store'
-import { IExchange } from './Exchange'
-import { ExchangeSymbol, TradeResult } from './TradeResult'
-import { Coin, PriceMap, StableUSDCoin } from './shared-lib/types'
-import { CacheProxy } from './CacheProxy'
+import {TradeMemo, TradeState} from './TradeMemo'
+import {Statistics} from './Statistics'
+import {Config, DefaultStore, IStore} from './Store'
+import {IExchange} from './Exchange'
+import {ExchangeSymbol, TradeResult} from './TradeResult'
+import {Coin, PriceMap, StableUSDCoin} from './shared-lib/types'
+import {CacheProxy} from './CacheProxy'
 
 export class V2Trader {
   private readonly store: IStore
@@ -265,12 +265,12 @@ export class V2Trader {
     if (growthIndex + TradeMemo.PriceMemoMaxCapacity <= 3) {
       CacheProxy.put(key, dumpStartPrice || tm.prices[0].toString(), 120); // 2 minutes
     } else if (dumpStartPrice) {
+      CacheProxy.remove(key);
       const dumpPercent = 100 * (1 - tm.currentPrice / +dumpStartPrice)
       if (dumpPercent >= this.config.DumpAlertPercentage) {
         Log.alert(`${tm.getCoinName()} price dumped ${dumpPercent.toFixed(2)}%: ${dumpStartPrice} -> ${tm.currentPrice}`);
         return true;
       }
-      CacheProxy.remove(key);
     }
     return false;
   }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -98,15 +98,15 @@ export function Settings() {
             />
           </Stack>
           <Stack direction="row" spacing={2}>
-            <TextField value={config.DumpAlertPercentage} label={"Dump Alert"}
-                       onChange={e => setConfig({...config, DumpAlertPercentage: +e.target.value})}
+            <TextField value={config.PriceAnomalyAlert} label={"Price Anomaly Alert"}
+                       onChange={e => setConfig({...config, PriceAnomalyAlert: +e.target.value})}
                        InputProps={{startAdornment: <InputAdornment position="start">%</InputAdornment>}}
             />
             <FormControlLabel
               control={
                 <Switch checked={config.BuyDumps}
                         onChange={e => setConfig({...config, BuyDumps: e.target.checked})}/>
-              } label="Auto-buy"
+              } label="Buy drops"
             />
           </Stack>
           <FormControlLabel

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -98,14 +98,14 @@ export function Settings() {
             />
           </Stack>
           <Stack direction="row" spacing={2}>
-            <TextField value={config.DipAlertPercentage} label={"Price Drop Alert"}
-                       onChange={e => setConfig({...config, DipAlertPercentage: +e.target.value})}
+            <TextField value={config.DumpAlertPercentage} label={"Dump Alert"}
+                       onChange={e => setConfig({...config, DumpAlertPercentage: +e.target.value})}
                        InputProps={{startAdornment: <InputAdornment position="start">%</InputAdornment>}}
             />
             <FormControlLabel
               control={
-                <Switch checked={config.BuyDips}
-                        onChange={e => setConfig({...config, BuyDips: e.target.checked})}/>
+                <Switch checked={config.BuyDumps}
+                        onChange={e => setConfig({...config, BuyDumps: e.target.checked})}/>
               } label="Auto-buy"
             />
           </Stack>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -14,25 +14,13 @@ import {
   TextField,
 } from "@mui/material";
 import {circularProgress} from "./Common";
-import {PriceProvider} from "../../apps-script/TradeResult";
 import {StableUSDCoin} from "../../apps-script/shared-lib/types";
 
 export function Settings() {
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState(null);
 
-  const [config, setConfig] = useState<Config>({
-    BuyQuantity: 0,
-    StopLimit: 0,
-    StableCoin: '' as StableUSDCoin,
-    SellAtStopLimit: false,
-    SellAtProfitLimit: false,
-    ProfitLimit: 0,
-    SwingTradeEnabled: false,
-    PriceProvider: PriceProvider.Binance,
-    AveragingDown: false,
-    ProfitBasedStopLimit: false
-  });
+  const [config, setConfig] = useState<Config>(null);
   const [configLoaded, setConfigLoaded] = useState(false);
 
   const [stopLimit, setLossLimit] = useState('');
@@ -107,6 +95,18 @@ export function Settings() {
                 <Switch checked={config.SellAtStopLimit}
                         onChange={e => setConfig({...config, SellAtStopLimit: e.target.checked})}/>
               } label="Auto-sell"
+            />
+          </Stack>
+          <Stack direction="row" spacing={2}>
+            <TextField value={config.DipAlertPercentage} label={"Price Drop Alert"}
+                       onChange={e => setConfig({...config, DipAlertPercentage: +e.target.value})}
+                       InputProps={{startAdornment: <InputAdornment position="start">%</InputAdornment>}}
+            />
+            <FormControlLabel
+              control={
+                <Switch checked={config.BuyDips}
+                        onChange={e => setConfig({...config, BuyDips: e.target.checked})}/>
+              } label="Auto-buy"
             />
           </Stack>
           <FormControlLabel

--- a/src/components/StableCoin.tsx
+++ b/src/components/StableCoin.tsx
@@ -1,30 +1,30 @@
-import * as React from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { TradeMemo } from '../../apps-script/TradeMemo';
-import { Config } from '../../apps-script/Store';
-import { f2 } from './Common';
+import * as React from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Typography from '@mui/material/Typography'
+import { TradeMemo } from '../../apps-script/TradeMemo'
+import { Config } from '../../apps-script/Store'
+import { f2 } from './Common'
 
 type StableCoinProps = {
-	tradeNotAllowed: boolean;
-	data: TradeMemo;
-	config: Config;
+  tradeNotAllowed: boolean;
+  data: TradeMemo;
+  config: Config;
 };
 
 export default function StableCoin({ data: tradeMemo }: StableCoinProps) {
-	const coinName = tradeMemo.getCoinName();
+  const coinName = tradeMemo.getCoinName()
 
-	return (
-		<>
-			<Card sx={{ width: 332 }}>
-				<CardContent sx={{ paddingBottom: 0 }}>
-					<Typography variant="h5">{coinName}</Typography>
-					<Typography variant="h6">
-						{f2(tradeMemo.tradeResult.quantity)}
-					</Typography>
-				</CardContent>
-			</Card>
-		</>
-	);
+  return (
+    <>
+      <Card sx={{ width: 332 }}>
+        <CardContent sx={{ paddingBottom: 0 }}>
+          <Typography variant='h5'>{coinName}</Typography>
+          <Typography variant='h6'>
+            {f2(tradeMemo.tradeResult.quantity)}
+          </Typography>
+        </CardContent>
+      </Card>
+    </>
+  )
 }

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -189,7 +189,8 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
         <Card elevation={2}>
           <CardContent>
             <TradeTitle tradeMemo={tm} onEdit={() => setEditMode(true)} onDelete={onDelete}/>
-            <Box width={chartOpts.width} height={chartOpts.height} ref={chartContainerRef} className="chart-container"/>
+            <Box sx={chartStyle(theme)} width={chartOpts.width} height={chartOpts.height} ref={chartContainerRef}
+                 className="chart-container"/>
           </CardContent>
           {!!tm.tradeResult.quantity ?
             <Typography marginLeft={"16px"} variant="body2" color="text.secondary">
@@ -246,6 +247,13 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
     </>
   );
 }
+
+const chartStyle = theme => ({
+  '& .tv-lightweight-charts': {
+    borderRadius: '4px',
+    border: `1px solid ${theme.palette.text.disabled}`
+  }
+})
 
 function changeChartTheme(chart: IChartApi, theme: Theme) {
   chart && chart.applyOptions({

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -18,8 +18,8 @@ import {
 } from 'lightweight-charts';
 import {Box, Stack, Theme, ToggleButton, useTheme} from "@mui/material";
 import {circularProgress, confirmBuy, confirmSell, f2} from "./Common";
-import {TradeEditDialog} from "./TradeEditDialog";
 import {TradeTitle} from "./TradeTitle";
+import {TradeEditDialog} from "./TradeEditDialog";
 
 export default function Trade(props: { data: TradeMemo, config: Config, tradeNotAllowed: boolean }) {
   const tm: TradeMemo = props.data;
@@ -28,7 +28,7 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
   const coinName = tm.getCoinName();
 
   const chartContainerRef = useRef();
-  const chart = useRef(null);
+  const chart = useRef<IChartApi>(null);
   const theme = useTheme();
 
   const [priceLine, setPriceLine] = useState<ISeriesApi<"Line">>(null);
@@ -89,9 +89,10 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
 
     if (limitLine) {
       limitLine.applyOptions({
-        visible: !!tm.stopLimitPrice,
-        // make dashed if config SellAtStopLimit is false or HODLing
-        lineStyle: !config.SellAtStopLimit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
+        // hide if HODLing or no stop limit price
+        visible: !!tm.stopLimitPrice && !tm.hodl,
+        // make dashed if config SellAtStopLimit is false
+        lineStyle: !config.SellAtStopLimit ? LineStyle.Dashed : LineStyle.Solid
       });
       limitLine.setData(map(tm.prices, () => tm.stopLimitPrice))
     }
@@ -103,10 +104,11 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
 
     if (profitLine) {
       profitLine.applyOptions({
-        visible: !!tm.tradeResult.quantity,
         color: profitLineColor,
-        // make dashed if config SellAtProfitLimit is false or HODLing
-        lineStyle: !config.SellAtProfitLimit || tm.hodl ? LineStyle.Dashed : LineStyle.Solid
+        // hide if HODLing or no quantity
+        visible: !!tm.tradeResult.quantity && !tm.hodl,
+        // make dashed if config SellAtProfitLimit is false
+        lineStyle: !config.SellAtProfitLimit ? LineStyle.Dashed : LineStyle.Solid
       });
       const profitPrice = tm.tradeResult.price * (1 + config.ProfitLimit);
       profitLine.setData(map(tm.prices, () => profitPrice))

--- a/src/components/Trade.tsx
+++ b/src/components/Trade.tsx
@@ -151,10 +151,7 @@ export default function Trade(props: { data: TradeMemo, config: Config, tradeNot
 
   function onCancel() {
     if (confirm(`Are you sure you want to cancel the action on ${coinName}?`)) {
-      const handle = resp => {
-        alert(resp.toString());
-        setActionCanceled(true);
-      };
+      const handle = () => setActionCanceled(true);
       google.script.run.withSuccessHandler(handle).withFailureHandler(alert).cancelAction(coinName);
     }
   }

--- a/src/components/TradeTitle.tsx
+++ b/src/components/TradeTitle.tsx
@@ -28,7 +28,7 @@ export function TradeTitle({tradeMemo, onEdit, onDelete}: {
   const [editHover, setEditHover] = useState(false);
   const [deleteHover, setDeleteHover] = useState(false);
 
-  const growthIndex = tradeMemo.getGrowthIndex(tradeMemo.prices);
+  const growthIndex = tradeMemo.getPriceChangeIndex(tradeMemo.prices);
 
   // normalize growth index to be in range -2 ... 2
   const ranges = 4;

--- a/src/components/TradeTitle.tsx
+++ b/src/components/TradeTitle.tsx
@@ -28,8 +28,15 @@ export function TradeTitle({tradeMemo, onEdit, onDelete}: {
   const [editHover, setEditHover] = useState(false);
   const [deleteHover, setDeleteHover] = useState(false);
 
-  const growthIndex = tradeMemo.getGrowthIndex(tradeMemo.prices.slice(-3));
-  const growthIcon = growthIconMap.get(growthIndex);
+  const growthIndex = tradeMemo.getGrowthIndex(tradeMemo.prices);
+
+  // normalize growth index to be in range -2 ... 2
+  const ranges = 4;
+  const normalIndex = Math.max(-2, Math.min(2,
+    +((growthIndex / (tradeMemo.prices.length - 1)) * ranges).toFixed(0)
+  ))
+
+  const growthIcon = growthIconMap.get(normalIndex);
 
   const editColor = editHover ? theme.palette.action.active : theme.palette.action.disabled;
   const editIcon = tradeMemo.stateIs(TradeState.BOUGHT) &&


### PR DESCRIPTION
## Change log

* Added Price Anomaly tracking for bought assets, which alerts when price dumps or pumps for the specified percentage.
* Added option to automatically buy price drops.

Future improvements:
* Be able to detect not just price drops, but price dips (aka temporary drops).
* Improve sensitivity and reliability over time.
* Other minor improvements:
  * Added alert when asset average price is crossed up.
  * Removed green/red lines on a chat for HODL assets

![image](https://user-images.githubusercontent.com/7527778/169696626-419dbdfa-6b56-43ff-be4a-d74fc764ec83.png)
