### PR TITLE
Feature: Improve price checking for Assets and Survivors

### DIFF
--- a/src/gas/PriceAnomalyChecker.ts
+++ b/src/gas/PriceAnomalyChecker.ts
@@ -2,7 +2,6 @@ import { CacheProxy } from "./CacheProxy"
 import { Log } from "./Common"
 import { TradeMemo } from "../shared-lib/TradeMemo"
 import { absPercentageChange } from "../shared-lib/functions"
-import { PriceMove } from "../shared-lib/types"
 
 export enum PriceAnomaly {
   NONE,
@@ -13,17 +12,10 @@ export enum PriceAnomaly {
 
 export class PriceAnomalyChecker {
   public static check(tm: TradeMemo, pdAlertPercentage: number): PriceAnomaly {
-    if (tm.prices.length < TradeMemo.PriceMemoMaxCapacity) {
-      return PriceAnomaly.NONE
-    }
-
     const key = `${tm.getCoinName()}-pump-dump-start`
     const anomalyStartPrice = CacheProxy.get(key)
 
-    const dump = tm.getPriceMove() === PriceMove.STRONG_DOWN
-    const pump = tm.getPriceMove() === PriceMove.STRONG_UP
-
-    if (pump || dump) {
+    if (tm.priceGoesUpStrong() || tm.priceGoesDownStrong()) {
       Log.debug(`${tm.getCoinName()} price anomaly detected`)
       CacheProxy.put(key, anomalyStartPrice || tm.prices[0].toString(), 120) // 2 minutes
       return PriceAnomaly.TRACKING

--- a/src/gas/Survivors.ts
+++ b/src/gas/Survivors.ts
@@ -33,14 +33,10 @@ export class Survivors implements ScoresManager {
   getScores(): CoinScore[] {
     const scoresJson = CacheProxy.get(`RecommenderMemos`)
     const scores: CoinScoreMap = scoresJson ? JSON.parse(scoresJson) : {}
-    const recommended: CoinScore[] = []
-    Object.keys(scores).forEach((k) => {
-      const cs = CoinScore.fromObject(scores[k])
-      if (cs.score > 0) {
-        recommended.push(cs)
-      }
-    })
-    return recommended.sort((a, b) => b.score - a.score).slice(0, 10)
+    return Object.values(scores)
+      .map(CoinScore.fromObject)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 10)
   }
 
   updateScores(): void {

--- a/src/gas/Survivors.ts
+++ b/src/gas/Survivors.ts
@@ -13,16 +13,16 @@ export interface ScoresManager {
   resetScores(): void
 }
 
-type CoinScoreMap = { [key: string]: CoinScore };
+type CoinScoreMap = { [key: string]: CoinScore }
 
 export class Survivors implements ScoresManager {
-  private readonly MARKET_UP_FRACTION = 0.01; // 1% (Binance has 2030 prices right now, 1% is ~20 coins)
-  private store: IStore;
-  private exchange: IExchange;
+  private readonly MARKET_UP_FRACTION = 0.01 // 1% (Binance has 2030 prices right now, 1% is ~20 coins)
+  private store: IStore
+  private exchange: IExchange
 
   constructor(store: IStore, exchange: IExchange) {
-    this.store = store;
-    this.exchange = exchange;
+    this.store = store
+    this.exchange = exchange
   }
 
   /**
@@ -31,54 +31,61 @@ export class Survivors implements ScoresManager {
    * Sorted by recommendation score.
    */
   getScores(): CoinScore[] {
-    const scoresJson = CacheProxy.get(`RecommenderMemos`);
-    const scores: CoinScoreMap = scoresJson ? JSON.parse(scoresJson) : {};
+    const scoresJson = CacheProxy.get(`RecommenderMemos`)
+    const scores: CoinScoreMap = scoresJson ? JSON.parse(scoresJson) : {}
     const recommended: CoinScore[] = []
-    Object.keys(scores).forEach(k => {
-      const cs = CoinScore.fromObject(scores[k]);
+    Object.keys(scores).forEach((k) => {
+      const cs = CoinScore.fromObject(scores[k])
       if (cs.score > 0) {
-        recommended.push(cs);
+        recommended.push(cs)
       }
     })
-    return recommended.sort((a, b) => b.score - a.score).slice(0, 10);
+    return recommended.sort((a, b) => b.score - a.score).slice(0, 10)
   }
 
   updateScores(): void {
-    const scoresJson = CacheProxy.get(`RecommenderMemos`);
-    const scores: CoinScoreMap = scoresJson ? JSON.parse(scoresJson) : this.store.get(`SurvivorScores`) || {};
-    const coinsRaisedAmidMarkedDown: CoinScoreMap = {};
-    const prices = this.exchange.getPrices();
-    Object.keys(prices).forEach(s => {
-      const coinName = s.endsWith(StableUSDCoin.USDT) ? s.split(StableUSDCoin.USDT)[0] : null;
+    const scoresJson = CacheProxy.get(`RecommenderMemos`)
+    const scores: CoinScoreMap = scoresJson
+      ? JSON.parse(scoresJson)
+      : this.store.get(`SurvivorScores`) || {}
+    const coinsRaisedAmidMarkedDown: CoinScoreMap = {}
+    const prices = this.exchange.getPrices()
+    Object.keys(prices).forEach((s) => {
+      const coinName = s.endsWith(StableUSDCoin.USDT) ? s.split(StableUSDCoin.USDT)[0] : null
       if (coinName) {
-        const price = prices[s];
-        const score = new CoinScore(coinName, scores[s])
-        score.pushPrice(price)
-        score.priceGoesUpStrong() && (coinsRaisedAmidMarkedDown[s] = score)
-        scores[s] = score;
+        const price = prices[s]
+        const cs = new CoinScore(coinName, scores[s])
+        cs.pushPrice(price)
+        cs.priceGoesUpStrong() && (coinsRaisedAmidMarkedDown[s] = cs)
+        scores[s] = cs
       }
     })
 
     // if only MARKET_UP_FRACTION% of coins go up, we update their recommendation score
-    const fractionMet = Object.keys(coinsRaisedAmidMarkedDown).length <= (this.MARKET_UP_FRACTION * Object.keys(prices).length);
+    const fractionMet =
+      Object.keys(coinsRaisedAmidMarkedDown).length <=
+      this.MARKET_UP_FRACTION * Object.keys(prices).length
     if (fractionMet && Object.keys(coinsRaisedAmidMarkedDown).length > 0) {
-      Object.values(coinsRaisedAmidMarkedDown).forEach(r => r.incrementScore());
-      Log.info(`Updated survivors.`);
+      Object.values(coinsRaisedAmidMarkedDown).forEach((r) => r.incrementScore())
+      Log.info(`Updated survivors.`)
     }
 
-    CacheProxy.put(`RecommenderMemos`, JSON.stringify(scores));
+    // delete zero scores from scores
+    Object.keys(scores).forEach((k) => !scores[k].score && delete scores[k])
+
+    CacheProxy.put(`RecommenderMemos`, JSON.stringify(scores))
 
     // Sync the scores to store every 6 hours
     if (!CacheProxy.get(`SurvivorScoresSynced`)) {
-      this.store.set(`SurvivorScores`, scores);
-      CacheProxy.put(`SurvivorScoresSynced`, `true`, 6 * 60 * 60); // 6 hours
+      this.store.set(`SurvivorScores`, scores)
+      CacheProxy.put(`SurvivorScoresSynced`, `true`, 6 * 60 * 60) // 6 hours
     }
   }
 
   resetScores(): void {
     // todo: make concurrent safe
-    CacheProxy.put(`RecommenderMemos`, JSON.stringify({}));
-    this.store.set(`SurvivorScores`, {});
-    CacheProxy.put(`SurvivorScoresSynced`, `true`, 6 * 60 * 60); // 6 hours
+    CacheProxy.put(`RecommenderMemos`, JSON.stringify({}))
+    this.store.set(`SurvivorScores`, {})
+    CacheProxy.put(`SurvivorScoresSynced`, `true`, 6 * 60 * 60) // 6 hours
   }
 }

--- a/src/gas/Survivors.ts
+++ b/src/gas/Survivors.ts
@@ -1,8 +1,9 @@
 import { IStore } from "./Store"
 import { CacheProxy } from "./CacheProxy"
-import { CoinScore, StableUSDCoin } from "../shared-lib/types"
+import { StableUSDCoin } from "../shared-lib/types"
 import { IExchange } from "./Exchange"
 import { Log } from "./Common"
+import { CoinScore } from "../shared-lib/CoinScore"
 
 export interface ScoresManager {
   getScores(): CoinScore[]
@@ -15,9 +16,9 @@ export interface ScoresManager {
 type CoinScoreMap = { [key: string]: CoinScore };
 
 export class Survivors implements ScoresManager {
+  private readonly MARKET_UP_FRACTION = 0.01; // 1% (Binance has 2030 prices right now, 1% is ~20 coins)
   private store: IStore;
   private exchange: IExchange;
-  private readonly MARKET_UP_FRACTION = 0.01; // 1% (Binance has 2030 prices right now, 1% is ~20 coins)
 
   constructor(store: IStore, exchange: IExchange) {
     this.store = store;
@@ -34,12 +35,12 @@ export class Survivors implements ScoresManager {
     const scores: CoinScoreMap = scoresJson ? JSON.parse(scoresJson) : {};
     const recommended: CoinScore[] = []
     Object.keys(scores).forEach(k => {
-      const r = CoinScore.fromObject(scores[k]);
-      if (r.getScore() > 0) {
-        recommended.push(r);
+      const cs = CoinScore.fromObject(scores[k]);
+      if (cs.score > 0) {
+        recommended.push(cs);
       }
     })
-    return recommended.sort((a, b) => b.getScore() - a.getScore()).slice(0, 10);
+    return recommended.sort((a, b) => b.score - a.score).slice(0, 10);
   }
 
   updateScores(): void {
@@ -51,9 +52,9 @@ export class Survivors implements ScoresManager {
       const coinName = s.endsWith(StableUSDCoin.USDT) ? s.split(StableUSDCoin.USDT)[0] : null;
       if (coinName) {
         const price = prices[s];
-        const score = CoinScore.new(coinName, scores[s]);
+        const score = new CoinScore(coinName, scores[s])
         score.pushPrice(price)
-        score.priceGoesUp() && (coinsRaisedAmidMarkedDown[s] = score)
+        score.priceGoesUpStrong() && (coinsRaisedAmidMarkedDown[s] = score)
         scores[s] = score;
       }
     })

--- a/src/gas/TradeActions.ts
+++ b/src/gas/TradeActions.ts
@@ -50,14 +50,18 @@ export class TradeActions {
   }
 
   static replace(coinName: string, newTrade: TradeMemo): void {
-    DefaultStore.changeTrade(coinName, (trade) => {
-      if (trade.getCoinName() != newTrade.getCoinName()) {
-        // if coin name changed reset prices
-        newTrade.prices = [0, 0, 0]
-        newTrade.stopLimitPrice = 0
-      }
-      return newTrade
-    }, () => newTrade)
+    DefaultStore.changeTrade(
+      coinName,
+      (trade) => {
+        if (trade.getCoinName() != newTrade.getCoinName()) {
+          // if coin name changed reset prices
+          newTrade.prices = []
+          newTrade.stopLimitPrice = 0
+        }
+        return newTrade
+      },
+      () => newTrade,
+    )
     if (coinName != newTrade.getCoinName()) {
       // if coin name changed delete old one
       TradeActions.drop(coinName)

--- a/src/gas/index.ts
+++ b/src/gas/index.ts
@@ -4,11 +4,12 @@ import { Statistics } from "./Statistics"
 import { Exchange } from "./Exchange"
 import { Survivors } from "./Survivors"
 import { Log } from "./Common"
-import { Coin, CoinScore, Stats } from "../shared-lib/types"
+import { Coin, Stats } from "../shared-lib/types"
 import { TradeMemo } from "../shared-lib/TradeMemo"
 import { Process } from "./Process"
 import { CacheProxy } from "./CacheProxy"
 import { AssetsResponse } from "../shared-lib/responses"
+import { CoinScore } from "../shared-lib/CoinScore"
 
 function doGet() {
   if (!ScriptApp.getProjectTriggers().find((t) => t.getHandlerFunction() == Process.tick.name)) {

--- a/src/shared-lib/CoinScore.ts
+++ b/src/shared-lib/CoinScore.ts
@@ -1,0 +1,40 @@
+import { PricesHolder } from "./PricesHolder"
+
+export class CoinScore extends PricesHolder {
+  private readonly n: string
+  private r = 0
+
+  /**
+   * @deprecated
+   */
+  private readonly c: string
+
+  constructor(coinName: string, obj?: CoinScore) {
+    super()
+    this.n = coinName
+    this.p = obj?.p ?? this.p
+    this.r = obj?.r ?? this.r
+  }
+
+  static fromObject(obj: CoinScore): CoinScore {
+    const rec = new CoinScore(obj.n || obj.c)
+    rec.r = obj.r
+    rec.p = obj.p
+    return rec
+  }
+
+  /**
+   * The number of times this coin was going up when the rest of the market wasn't.
+   */
+  get score(): number {
+    return this.r
+  }
+
+  get coinName(): string {
+    return this.n
+  }
+
+  incrementScore() {
+    this.r++
+  }
+}

--- a/src/shared-lib/PricesHolder.ts
+++ b/src/shared-lib/PricesHolder.ts
@@ -3,7 +3,11 @@ import { PriceMove } from "./types"
 
 export class PricesHolder {
   static readonly PRICES_MAX_CAP = 10
-  protected p: number[] = []
+  protected p: number[]
+
+  constructor() {
+    this.p = new Array(PricesHolder.PRICES_MAX_CAP).fill(0)
+  }
 
   /**
    * Keeps the latest measures of the price.

--- a/src/shared-lib/PricesHolder.ts
+++ b/src/shared-lib/PricesHolder.ts
@@ -16,22 +16,24 @@ export class PricesHolder {
     return this.p
   }
 
-  set prices(p: number[]) {
-    this.p = p
+  set prices(prices: number[]) {
+    const tempHolder = new PricesHolder()
+    // Using a temporary PricesHolder to ensure that prices array is of exact length
+    prices?.forEach((p) => tempHolder.pushPrice(p))
+    this.p = tempHolder.p
   }
 
   get currentPrice(): number {
-    return this.prices[this.prices.length - 1]
+    return this.p[this.p.length - 1]
   }
 
   pushPrice(price: number): void {
-    if (!this.prices.length || this.prices[0] === 0) {
-      // initial state, filling PriceMemoMaxCapacity with price
-      this.prices = new Array(PricesHolder.PRICES_MAX_CAP).fill(price)
+    if (!this.p.length || this.p[0] === 0) {
+      this.p = new Array(PricesHolder.PRICES_MAX_CAP).fill(price)
     } else {
-      this.prices.push(price)
+      this.p.push(price)
       // remove old prices and keep only the last PriceMemoMaxCapacity
-      this.prices.splice(0, this.prices.length - PricesHolder.PRICES_MAX_CAP)
+      this.p.splice(0, this.p.length - PricesHolder.PRICES_MAX_CAP)
     }
   }
 
@@ -52,6 +54,6 @@ export class PricesHolder {
   }
 
   getPriceMove(): PriceMove {
-    return getPriceMove(PricesHolder.PRICES_MAX_CAP, this.prices)
+    return getPriceMove(PricesHolder.PRICES_MAX_CAP, this.p)
   }
 }

--- a/src/shared-lib/PricesHolder.ts
+++ b/src/shared-lib/PricesHolder.ts
@@ -2,7 +2,7 @@ import { getPriceMove } from "./functions"
 import { PriceMove } from "./types"
 
 export class PricesHolder {
-  protected static readonly PRICES_MAX_CAP = 10
+  static readonly PRICES_MAX_CAP = 10
   protected p: number[] = []
 
   /**

--- a/src/shared-lib/PricesHolder.ts
+++ b/src/shared-lib/PricesHolder.ts
@@ -2,7 +2,7 @@ import { getPriceMove } from "./functions"
 import { PriceMove } from "./types"
 
 export class PricesHolder {
-  protected readonly PRICES_MAX_CAP = 10
+  protected static readonly PRICES_MAX_CAP = 10
   protected p: number[] = []
 
   /**
@@ -23,11 +23,11 @@ export class PricesHolder {
   pushPrice(price: number): void {
     if (!this.prices.length || this.prices[0] === 0) {
       // initial state, filling PriceMemoMaxCapacity with price
-      this.prices = new Array(this.PRICES_MAX_CAP).fill(price)
+      this.prices = new Array(PricesHolder.PRICES_MAX_CAP).fill(price)
     } else {
       this.prices.push(price)
       // remove old prices and keep only the last PriceMemoMaxCapacity
-      this.prices.splice(0, this.prices.length - this.PRICES_MAX_CAP)
+      this.prices.splice(0, this.prices.length - PricesHolder.PRICES_MAX_CAP)
     }
   }
 
@@ -48,6 +48,6 @@ export class PricesHolder {
   }
 
   getPriceMove(): PriceMove {
-    return getPriceMove(this.PRICES_MAX_CAP, this.prices)
+    return getPriceMove(PricesHolder.PRICES_MAX_CAP, this.prices)
   }
 }

--- a/src/shared-lib/PricesHolder.ts
+++ b/src/shared-lib/PricesHolder.ts
@@ -1,0 +1,53 @@
+import { getPriceMove } from "./functions"
+import { PriceMove } from "./types"
+
+export class PricesHolder {
+  protected readonly PRICES_MAX_CAP = 10
+  protected p: number[] = []
+
+  /**
+   * Keeps the latest measures of the price.
+   */
+  get prices() {
+    return this.p
+  }
+
+  set prices(p: number[]) {
+    this.p = p
+  }
+
+  get currentPrice(): number {
+    return this.prices[this.prices.length - 1]
+  }
+
+  pushPrice(price: number): void {
+    if (!this.prices.length || this.prices[0] === 0) {
+      // initial state, filling PriceMemoMaxCapacity with price
+      this.prices = new Array(this.PRICES_MAX_CAP).fill(price)
+    } else {
+      this.prices.push(price)
+      // remove old prices and keep only the last PriceMemoMaxCapacity
+      this.prices.splice(0, this.prices.length - this.PRICES_MAX_CAP)
+    }
+  }
+
+  priceGoesUp(): boolean {
+    return this.getPriceMove() >= PriceMove.UP
+  }
+
+  priceGoesUpStrong(): boolean {
+    return this.getPriceMove() >= PriceMove.STRONG_UP
+  }
+
+  priceGoesDown(): boolean {
+    return this.getPriceMove() <= PriceMove.DOWN
+  }
+
+  priceGoesDownStrong(): boolean {
+    return this.getPriceMove() <= PriceMove.STRONG_DOWN
+  }
+
+  getPriceMove(): PriceMove {
+    return getPriceMove(this.PRICES_MAX_CAP, this.prices)
+  }
+}

--- a/src/shared-lib/TradeMemo.ts
+++ b/src/shared-lib/TradeMemo.ts
@@ -49,7 +49,7 @@ export class TradeMemo extends PricesHolder {
     const tradeMemo: TradeMemo = Object.assign(new TradeMemo(null), obj)
     tradeMemo.tradeResult = Object.assign(new TradeResult(null), tradeMemo.tradeResult)
     tradeMemo.tradeResult.symbol = ExchangeSymbol.fromObject(tradeMemo.tradeResult.symbol)
-    tradeMemo.prices = tradeMemo.prices || [0, 0, 0]
+    tradeMemo.prices = tradeMemo.prices || []
     return tradeMemo
   }
 

--- a/src/shared-lib/TradeMemo.ts
+++ b/src/shared-lib/TradeMemo.ts
@@ -1,14 +1,9 @@
 import { TradeResult } from "./TradeResult"
-import { ExchangeSymbol, PriceMemo, PriceMove, TradeState } from "./types"
+import { ExchangeSymbol, TradeState } from "./types"
+import { PricesHolder } from "./PricesHolder"
 
-export class TradeMemo {
-  static readonly PriceMemoMaxCapacity = 10
-
+export class TradeMemo extends PricesHolder {
   tradeResult: TradeResult
-  /**
-   * Keeps the latest measures of the asset price.
-   */
-  prices: PriceMemo = [0, 0, 0]
   /**
    * Marks the asset for holding even if price drops.
    */
@@ -32,6 +27,7 @@ export class TradeMemo {
   private state: TradeState
 
   constructor(tradeResult: TradeResult) {
+    super()
     this.tradeResult = tradeResult
   }
 
@@ -55,10 +51,6 @@ export class TradeMemo {
     tradeMemo.tradeResult.symbol = ExchangeSymbol.fromObject(tradeMemo.tradeResult.symbol)
     tradeMemo.prices = tradeMemo.prices || [0, 0, 0]
     return tradeMemo
-  }
-
-  get currentPrice(): number {
-    return this.prices[this.prices.length - 1]
   }
 
   get maxObservedPrice(): number {
@@ -92,14 +84,7 @@ export class TradeMemo {
   }
 
   pushPrice(price: number): void {
-    if (!this.prices || !this.prices.length || this.prices[0] === 0) {
-      // initial state, filling PriceMemoMaxCapacity with price
-      this.prices = new Array(TradeMemo.PriceMemoMaxCapacity).fill(price) as PriceMemo
-    } else {
-      this.prices.push(price)
-      // remove old prices and keep only the last PriceMemoMaxCapacity
-      this.prices.splice(0, this.prices.length - TradeMemo.PriceMemoMaxCapacity)
-    }
+    super.pushPrice(price)
     this.maxObservedPrice = Math.max(this.maxObservedPrice, ...this.prices)
   }
 
@@ -172,43 +157,5 @@ export class TradeMemo {
     // all prices except the last one are lower the price at which the trade was bought
     const entryPrice = this.tradeResult.price
     return this.currentPrice > entryPrice && this.prices.slice(0, -1).every((p) => p <= entryPrice)
-  }
-
-  priceGoesUp(): boolean {
-    return this.getPriceMove() === PriceMove.UP
-  }
-
-  priceGoesUpStrong(): boolean {
-    return this.getPriceMove() === PriceMove.STRONG_UP
-  }
-
-  /**
-   * Returns the number of consecutive prices that are increasing.
-   * The result is negative if prices are decreasing.
-   * @example [3, 2, 1] => -2
-   * @example [2, 2, 1] => -1
-   * @example [1, 2, 2] => 0
-   * @example [2, 2, 3] => 1
-   * @example [1, 2, 3] => 2
-   * @param prices
-   */
-  getPriceChangeIndex(prices: number[]): number {
-    let result = 0
-    // if next price greater than current price, increase result
-    // otherwise decrease result
-    for (let i = 1; i < prices.length; i++) {
-      if (prices[i] > prices[i - 1]) {
-        result++
-      } else {
-        result--
-      }
-    }
-    return result
-  }
-
-  getPriceMove(): PriceMove {
-    const max = TradeMemo.PriceMemoMaxCapacity
-    const index = this.getPriceChangeIndex(this.prices)
-    return +(((index + max) / (2 * max)) * PriceMove.STRONG_UP).toFixed(0)
   }
 }

--- a/src/shared-lib/functions.ts
+++ b/src/shared-lib/functions.ts
@@ -1,10 +1,9 @@
+import { PriceMove } from "./types"
+
 export function sumWithMaxPrecision(a: number, b: number): number {
   const aSplit = `${a}`.split(`.`)
   const bSplit = `${b}`.split(`.`)
-  const precision = Math.max(
-    (aSplit[1] || aSplit[0]).length,
-    (bSplit[1] || bSplit[0]).length,
-  )
+  const precision = Math.max((aSplit[1] || aSplit[0]).length, (bSplit[1] || bSplit[0]).length)
   return +(a + b).toFixed(precision)
 }
 
@@ -19,4 +18,33 @@ export function absPercentageChange(v1: number, v2: number): number {
 
 export function f2(n: number): number {
   return +n.toFixed(2)
+}
+
+/**
+ * Returns the number of consecutive prices that are increasing.
+ * The result is negative if prices are decreasing.
+ * @example [3, 2, 1] => -2
+ * @example [2, 2, 1] => -1
+ * @example [1, 2, 2] => 0
+ * @example [2, 2, 3] => 1
+ * @example [1, 2, 3] => 2
+ * @param prices
+ */
+export function getPriceChangeIndex(prices: number[]): number {
+  let result = 0
+  // if next price greater than current price, increase result
+  // otherwise decrease result
+  for (let i = 1; i < prices.length; i++) {
+    if (prices[i] > prices[i - 1]) {
+      result++
+    } else {
+      result--
+    }
+  }
+  return result
+}
+
+export function getPriceMove(maxCapacity: number, prices: number[]): PriceMove {
+  const index = getPriceChangeIndex(prices)
+  return +(((index + maxCapacity) / (2 * maxCapacity)) * PriceMove.STRONG_UP).toFixed(0)
 }

--- a/src/shared-lib/types.ts
+++ b/src/shared-lib/types.ts
@@ -4,65 +4,6 @@ export enum StableUSDCoin {
   BUSD = `BUSD`,
 }
 
-export class CoinScore {
-  static readonly PRICES_MAX_CAP = 5
-  /**
-   * `r` is the number of times this memo was going up when the rest of the market wasn't.
-   */
-  private r = 0
-  private p: number[] = []
-  private readonly n: string
-
-  /**
-   * @deprecated
-   */
-  private readonly c: string
-
-  constructor(coinName: string) {
-    this.n = coinName
-  }
-
-  static new(coinName: string, obj?: CoinScore): CoinScore {
-    const score = new CoinScore(coinName)
-    score.p = obj?.p ?? score.p
-    score.r = obj?.r ?? score.r
-    return score
-  }
-
-  static fromObject(obj: CoinScore): CoinScore {
-    const rec = new CoinScore(obj.n || obj.c)
-    rec.r = obj.r
-    rec.p = obj.p
-    return rec
-  }
-
-  incrementScore() {
-    this.r++
-  }
-
-  getScore(): number {
-    return this.r
-  }
-
-  getCoinName(): string {
-    return this.n
-  }
-
-  priceGoesUp(): boolean {
-    if (this.p.length < CoinScore.PRICES_MAX_CAP) {
-      return false
-    }
-    return this.p.every((p, i) => (i == 0 ? true : p > this.p[i - 1]))
-  }
-
-  pushPrice(price: number): void {
-    this.p.push(price)
-    if (this.p.length > CoinScore.PRICES_MAX_CAP) {
-      this.p.splice(0, this.p.length - CoinScore.PRICES_MAX_CAP)
-    }
-  }
-}
-
 export type PriceMap = { [key: string]: number }
 
 export type Stats = {
@@ -105,8 +46,6 @@ export enum TradeState {
   SELL = `sell`,
   SOLD = `sold`,
 }
-
-export type PriceMemo = [number, number, number]
 
 export class Coin {
   readonly name: string

--- a/src/web/components/Survivors.tsx
+++ b/src/web/components/Survivors.tsx
@@ -14,7 +14,7 @@ import {
 import { Refresh } from "@mui/icons-material"
 import { Config } from "../../gas/Store"
 import { confirmBuy } from "./Common"
-import { CoinScore } from "../../shared-lib/types"
+import { CoinScore } from "../../shared-lib/CoinScore"
 
 export function Survivors({ config }: { config: Config }) {
   const [survivors, setSurvivors] = React.useState<CoinScore[]>([])
@@ -39,13 +39,13 @@ export function Survivors({ config }: { config: Config }) {
         {!!survivors.length && (
           <List sx={{ padding: 0, width: 332 }}>
             {survivors.map((rJson, i) => {
-              const r = CoinScore.fromObject(rJson)
+              const cs = CoinScore.fromObject(rJson)
               return (
                 <ListItem
-                  key={r.getCoinName()}
+                  key={cs.coinName}
                   disablePadding={true}
                   secondaryAction={
-                    <Button size={`small`} onClick={() => buy(r.getCoinName())}>
+                    <Button size={`small`} onClick={() => buy(cs.coinName)}>
                       Buy
                     </Button>
                   }
@@ -53,8 +53,8 @@ export function Survivors({ config }: { config: Config }) {
                   <ListItemAvatar>#{i + 1}</ListItemAvatar>
                   <ListItemText
                     sx={{ marginBottom: 0 }}
-                    primary={r.getCoinName()}
-                    secondary={`Score: ${r.getScore()}`}
+                    primary={cs.coinName}
+                    secondary={`Score: ${cs.score}`}
                   />
                 </ListItem>
               )


### PR DESCRIPTION
## Change log

* Unified price checking for Assets and Survivors: keep 10 measures in both features.
* Fixed the priceGoesUp function to return true for >= PriceMove.UP (which includes PriceMove.STRONG_UP).
* Increment Survivor score when PriceMove.STRONG_UP (which means the score will be more accurate, but happen rarely).