### PR TITLE
Feature: Auto Trade Best Scores

### DIFF
--- a/src/gas/Process.ts
+++ b/src/gas/Process.ts
@@ -4,12 +4,14 @@ import { Statistics } from "./Statistics"
 import { DeadlineError, DefaultStore } from "./Store"
 import { Scores } from "./Scores"
 import { Log } from "./Common"
+import { ScoreTrader } from "./ScoreTrader"
 
 export class Process {
   static tick() {
     const store = DefaultStore
     const exchange = new Exchange(store.getConfig())
     const trader = new V2Trader(store, exchange, new Statistics(store))
+    const scores = new Scores(store, exchange)
 
     store.getTradesList().forEach((trade) => {
       try {
@@ -27,15 +29,24 @@ export class Process {
     try {
       trader.updateStableCoinsBalance()
     } catch (e) {
-      Log.error(new Error(`Failed to read stable coins balance: ${e.message}`))
+      Log.alert(`Failed to read stable coins balance`)
+      Log.error(e)
+    }
+
+    try {
+      scores.update()
+    } catch (e) {
+      Log.alert(`Failed to update scores`)
+      Log.error(e)
+    }
+
+    try {
+      new ScoreTrader(store, scores).trade()
+    } catch (e) {
+      Log.alert(`Failed to trade recommended coins`)
+      Log.error(e)
     }
 
     store.dumpChanges()
-
-    try {
-      new Scores(store, exchange).update()
-    } catch (e) {
-      Log.error(e)
-    }
   }
 }

--- a/src/gas/ScoreTrader.ts
+++ b/src/gas/ScoreTrader.ts
@@ -1,0 +1,41 @@
+import { IStore } from "./Store"
+import { Scores } from "./Scores"
+import { Log } from "./Common"
+import { TradeActions } from "./TradeActions"
+import { TradeState } from "../shared-lib/types"
+
+export class ScoreTrader {
+  private store: IStore
+  private scores: Scores
+
+  constructor(store: IStore, scores: Scores) {
+    this.store = store
+    this.scores = scores
+  }
+
+  /**
+   * If {@link AutoTradeBestScores} is enabled, get recommended coins from scores and
+   * if they are not already in the portfolio, buy them.
+   * Coins that are sold and not in the recommended list are removed from the portfolio.
+   */
+  trade(): void {
+    const tradeBestScores = this.store.getConfig().AutoTradeBestScores
+    if (tradeBestScores) {
+      const recommended = this.scores.getRecommended().slice(0, tradeBestScores)
+
+      // buy new coins from recommended list
+      recommended
+        .filter((cs) => !this.store.hasTrade(cs.coinName))
+        .forEach((cs) => {
+          Log.alert(`➕ Auto Trade Best Scores: ${cs.coinName} picked`)
+          TradeActions.buy(cs.coinName)
+        })
+
+      // remove sold coins that are not in the recommended list
+      this.store
+        .getTradesList(TradeState.SOLD)
+        .filter((tm) => !recommended.find((cs) => cs.coinName === tm.getCoinName()))
+        .forEach((tm) => TradeActions.drop(tm.getCoinName()))
+    }
+  }
+}

--- a/src/gas/Store.ts
+++ b/src/gas/Store.ts
@@ -1,7 +1,6 @@
 import { CacheProxy } from "./CacheProxy"
 import {
   AutoTradeBestScores,
-  ExchangeSymbol,
   PriceProvider,
   ScoreSelectivity,
   StableUSDCoin,
@@ -34,7 +33,7 @@ export interface IStore {
 
   getTradesList(state?: TradeState): TradeMemo[]
 
-  getTrade(symbol: ExchangeSymbol): TradeMemo
+  hasTrade(coinName: string): boolean
 
   changeTrade(
     coinName: string,
@@ -191,8 +190,8 @@ export class FirebaseStore implements IStore {
     return state ? values.filter((trade) => trade.stateIs(state)) : values
   }
 
-  getTrade(symbol: ExchangeSymbol): TradeMemo {
-    return this.getTrades()[symbol.quantityAsset]
+  hasTrade(coinName: string): boolean {
+    return !!this.getTrades()[coinName]
   }
 
   /**

--- a/src/gas/Store.ts
+++ b/src/gas/Store.ts
@@ -1,5 +1,6 @@
 import { CacheProxy } from "./CacheProxy"
 import {
+  AutoTradeBestScores,
   ExchangeSymbol,
   PriceProvider,
   ScoreSelectivity,
@@ -99,6 +100,7 @@ export class FirebaseStore implements IStore {
       ProfitBasedStopLimit: false,
       PriceAnomalyAlert: 5,
       ScoreUpdateThreshold: ScoreSelectivity.MODERATE,
+      AutoTradeBestScores: AutoTradeBestScores.OFF,
     }
     const configCacheJson = CacheProxy.get(`Config`)
     let configCache: Config = configCacheJson ? JSON.parse(configCacheJson) : null
@@ -312,6 +314,11 @@ export type Config = {
    * the scores will be recalculated for that 1%.
    */
   ScoreUpdateThreshold?: number
+  /**
+   * AutoTradeBestScores - when enabled, the tool will trade the "Scores" recommended coins automatically.
+   * If the coin falls out of the recommended list, it will be removed from the assets once it is sold.
+   */
+  AutoTradeBestScores?: AutoTradeBestScores
 
   /**
    * @deprecated

--- a/src/gas/Trader.ts
+++ b/src/gas/Trader.ts
@@ -17,11 +17,11 @@ export class V2Trader {
   private readonly prices: PriceMap
 
   /**
-   * Used when {@link Config.ProfitBasedStopLimit} is enabled.
+   * Used when {@link ProfitBasedStopLimit} is enabled.
    */
   private readonly totalProfit: number
   /**
-   * Used when {@link Config.ProfitBasedStopLimit} is enabled.
+   * Used when {@link ProfitBasedStopLimit} is enabled.
    */
   private readonly numberOfBoughtAssets: number
 

--- a/src/shared-lib/TradeMemo.ts
+++ b/src/shared-lib/TradeMemo.ts
@@ -13,7 +13,7 @@ export class TradeMemo extends PricesHolder {
    */
   deleted: boolean
   /**
-   * The price at which the asset should be sold automatically if {@link Config.SellAtStopLimit}
+   * The price at which the asset should be sold automatically if {@link SellAtStopLimit}
    * is true, and {@link TradeMemo.hodl} is false.
    */
   private stopLimit = 0

--- a/src/shared-lib/functions.ts
+++ b/src/shared-lib/functions.ts
@@ -13,7 +13,7 @@ export function getRandomFromList(list) {
 
 export function absPercentageChange(v1: number, v2: number): number {
   // |100 x (v2 - v1) / |v1||
-  return f2(Math.abs(100 * (v2 - v1) / Math.abs(v1)))
+  return f2(Math.abs((100 * (v2 - v1)) / Math.abs(v1)))
 }
 
 export function f2(n: number): number {
@@ -47,4 +47,8 @@ export function getPriceChangeIndex(prices: number[]): number {
 export function getPriceMove(maxCapacity: number, prices: number[]): PriceMove {
   const index = getPriceChangeIndex(prices)
   return +(((index + maxCapacity) / (2 * maxCapacity)) * PriceMove.STRONG_UP).toFixed(0)
+}
+
+export function enumKeys(enumType: any): string[] {
+  return Object.keys(enumType).filter(k => isNaN(Number(k)))
 }

--- a/src/shared-lib/types.ts
+++ b/src/shared-lib/types.ts
@@ -84,3 +84,11 @@ export enum ScoreSelectivity {
   MODERATE = 0.05,
   MINIMAL = 0.1,
 }
+
+export enum AutoTradeBestScores {
+  OFF = 0,
+  TOP1 = 1,
+  TOP3 = 3,
+  TOP5 = 5,
+  TOP10 = 10,
+}

--- a/src/web/components/Scores.tsx
+++ b/src/web/components/Scores.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { useEffect } from "react"
 import {
+  Alert,
   Box,
   Button,
   List,
@@ -11,11 +12,11 @@ import {
   Typography,
 } from "@mui/material"
 import { Config } from "../../gas/Store"
-import { circularProgress, confirmBuy, growthIconMap } from "./Common"
+import { capitalizeWord, circularProgress, confirmBuy, growthIconMap } from "./Common"
 import { CoinScore } from "../../shared-lib/CoinScore"
 import { ScoresResponse } from "../../shared-lib/responses"
 import { f2 } from "../../shared-lib/functions"
-import { PriceMove } from "../../shared-lib/types"
+import { AutoTradeBestScores, PriceMove } from "../../shared-lib/types"
 
 export function Scores({ config }: { config: Config }) {
   const [scores, setScores] = React.useState<ScoresResponse>(null)
@@ -45,7 +46,7 @@ export function Scores({ config }: { config: Config }) {
       {scores && (
         <Stack spacing={2}>
           {marketMoveBlock(scores)}
-          {recommendedList(scores, buy)}
+          {recommendedList(scores, buy, config.AutoTradeBestScores)}
           <Stack alignSelf={`center`} direction={`row`}>
             {!!scores.recommended.length && (
               <Button
@@ -74,12 +75,17 @@ export function Scores({ config }: { config: Config }) {
   )
 }
 
-function recommendedList(scores: ScoresResponse, buy: (coinName: string) => void) {
+function recommendedList(
+  scores: ScoresResponse,
+  buy: (coinName: string) => void,
+  autoTrade: AutoTradeBestScores,
+) {
   return (
     <>
-      <Typography alignSelf={`center`} variant={`subtitle1`}>
-        Recommended
-      </Typography>
+      <Stack>
+        <Typography alignSelf={`center`} variant={`subtitle1`}>Recommended</Typography>
+        {autoTrade && getAlert(autoTrade)}
+      </Stack>
       {!scores.recommended.length && (
         <Typography alignSelf={`center`} variant={`caption`}>
           Nothing to show yet.
@@ -134,5 +140,25 @@ function marketMoveBlock(scores: ScoresResponse) {
           )}
       </Stack>
     </>
+  )
+}
+
+function getAlert(autoTrade: AutoTradeBestScores) {
+  return (
+    <Alert
+      severity={`info`}
+      sx={{
+        margin: 0,
+        padding: 0,
+        justifyContent: `center`,
+        "& div": {
+          padding: `1px 0`,
+        },
+      }}
+    >
+      <Typography marginTop={0} alignSelf={`center`} variant={`caption`}>
+        Auto-buying {capitalizeWord(AutoTradeBestScores[autoTrade])}
+      </Typography>
+    </Alert>
   )
 }

--- a/src/web/components/Settings.tsx
+++ b/src/web/components/Settings.tsx
@@ -14,13 +14,14 @@ import {
   InputAdornment,
   Radio,
   RadioGroup,
+  Slider,
   Stack,
   Switch,
   TextField,
 } from "@mui/material"
-import { circularProgress } from "./Common"
-import { StableUSDCoin } from "../../shared-lib/types"
-import { f2 } from "../../shared-lib/functions"
+import { capitalizeWord, circularProgress } from "./Common"
+import { AutoTradeBestScores, StableUSDCoin } from "../../shared-lib/types"
+import { enumKeys, f2 } from "../../shared-lib/functions"
 
 export function Settings() {
   const [isSaving, setIsSaving] = useState(false)
@@ -161,7 +162,7 @@ export function Settings() {
             label="Averaging down"
           />
           {advancedSettings(hideAdvanced, setHideAdvanced, config, setConfig)}
-          <Box marginTop={`24px`} alignSelf={`center`} sx={{ position: `relative` }}>
+          <Box paddingTop={`24px`} alignSelf={`center`} sx={{ position: `relative` }}>
             <Button
               variant="contained"
               color="primary"
@@ -210,6 +211,8 @@ function advancedSettings(
               label="Buy drops"
             />
           </Stack>
+          <Divider />
+          {autoTradeBestScoresSlider(config, setConfig)}
           {scoreThresholdSelector(config, setConfig)}
         </Stack>
       )}
@@ -241,6 +244,28 @@ function scoreThresholdSelector(config: Config, setConfig: (config: Config) => v
         />
         <FormControlLabel labelPlacement="bottom" value={0.1} control={<Radio />} label="Minimal" />
       </RadioGroup>
+    </FormControl>
+  )
+}
+
+function autoTradeBestScoresSlider(config: Config, setConfig: (config: Config) => void) {
+  return (
+    <FormControl>
+      <FormLabel>Auto Trade Best Scores</FormLabel>
+      <Slider
+        sx={{ marginLeft: `8px` }}
+        value={config.AutoTradeBestScores}
+        onChange={(e, value) =>
+          setConfig({ ...config, AutoTradeBestScores: value as AutoTradeBestScores })
+        }
+        step={null}
+        min={0}
+        max={10}
+        marks={enumKeys(AutoTradeBestScores).map((key) => ({
+          value: AutoTradeBestScores[key],
+          label: capitalizeWord(key),
+        }))}
+      />
     </FormControl>
   )
 }

--- a/src/web/components/Settings.tsx
+++ b/src/web/components/Settings.tsx
@@ -92,12 +92,14 @@ export function Settings() {
               ))}
             </RadioGroup>
           </FormControl>
+          <Divider />
           <TextField
             value={buyQuantity}
             label={`Buy Quantity`}
             onChange={(e) => setBuyQuantity(e.target.value)}
             InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
           />
+          <Divider />
           <Stack direction="row" spacing={2}>
             <TextField
               value={profitLimit}
@@ -133,6 +135,7 @@ export function Settings() {
               label="Auto-sell"
             />
           </Stack>
+          <Divider />
           <FormControlLabel
             sx={{ margin: 0 }}
             control={
@@ -162,7 +165,7 @@ export function Settings() {
             label="Averaging down"
           />
           {advancedSettings(hideAdvanced, setHideAdvanced, config, setConfig)}
-          <Box paddingTop={`24px`} alignSelf={`center`} sx={{ position: `relative` }}>
+          <Box alignSelf={`center`} sx={{ position: `relative` }}>
             <Button
               variant="contained"
               color="primary"
@@ -214,6 +217,7 @@ function advancedSettings(
           <Divider />
           {autoTradeBestScoresSlider(config, setConfig)}
           {scoreThresholdSelector(config, setConfig)}
+          <Divider />
         </Stack>
       )}
     </>
@@ -253,7 +257,7 @@ function autoTradeBestScoresSlider(config: Config, setConfig: (config: Config) =
     <FormControl>
       <FormLabel>Auto Trade Best Scores</FormLabel>
       <Slider
-        sx={{ marginLeft: `8px` }}
+        sx={{ marginLeft: `10px` }}
         value={config.AutoTradeBestScores}
         onChange={(e, value) =>
           setConfig({ ...config, AutoTradeBestScores: value as AutoTradeBestScores })

--- a/src/web/components/Trade.tsx
+++ b/src/web/components/Trade.tsx
@@ -214,9 +214,11 @@ export default function Trade(props: { data: TradeMemo; config: Config; coinName
               </div>
             </Typography>
           ) : (
-            <Typography marginLeft={`16px`} variant="body2" color="text.secondary">
-              <div>Gap: {f2(tm.soldPriceChangePercent())}%</div>
-            </Typography>
+            !!tm.soldPriceChangePercent() && (
+              <Typography marginLeft={`16px`} variant="body2" color="text.secondary">
+                <div>Gap: {f2(tm.soldPriceChangePercent())}%</div>
+              </Typography>
+            )
           )}
           <CardActions>
             <Stack direction={`row`} spacing={1} sx={{ marginLeft: `auto`, marginRight: `auto` }}>
@@ -294,14 +296,14 @@ const chartStyle = (theme) => ({
 
 function changeChartTheme(chart: IChartApi, theme: Theme) {
   chart &&
-  chart.applyOptions({
-    layout: {
-      backgroundColor: theme.palette.background.default,
-      textColor: theme.palette.text.primary,
-    },
-    grid: {
-      vertLines: { color: theme.palette.divider },
-      horzLines: { color: theme.palette.divider },
-    },
-  })
+    chart.applyOptions({
+      layout: {
+        backgroundColor: theme.palette.background.default,
+        textColor: theme.palette.text.primary,
+      },
+      grid: {
+        vertLines: { color: theme.palette.divider },
+        horzLines: { color: theme.palette.divider },
+      },
+    })
 }


### PR DESCRIPTION
## Change log

* Added Setting to automatically buy top 1, 3, 5 or 10 coins for the "Scores" - "Recommended" list.
* It buys only those recommended coins that are not in the portfolio yet.
* If coin is no longer in the selected recommended list it is removed from the "Sold" coins if it is there.

### Settings -> Advanced
![image](https://user-images.githubusercontent.com/7527778/170879258-1ba67a02-3eec-4954-9b13-71b7b4b3f6ca.png)
### Scores
![image](https://user-images.githubusercontent.com/7527778/170879240-ea41ad48-608c-428d-b444-83ba00b24ac9.png)
